### PR TITLE
Fix syntax error in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 
 sudo: false
 
-node_js: "10
+node_js: 10


### PR DESCRIPTION
This broke Travis tests (last Travis job run 8 months ago, last change was 6 months ago)