### PR TITLE
Fix exception handling constructs

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -285,8 +285,12 @@ grammar({
     try_statement: $ => seq(
       'try',
       optional($._expression_list),
-      optional($.catch_clause),
-      optional($.finally_clause),
+      choice(
+        $.catch_clause,
+        $.finally_clause,
+        seq($.catch_clause, $.finally_clause),
+        seq($.finally_clause, $.catch_clause)
+      ),
       'end'
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -972,19 +972,34 @@
               "name": "catch_clause"
             },
             {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
               "type": "SYMBOL",
               "name": "finally_clause"
             },
             {
-              "type": "BLANK"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "catch_clause"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "finally_clause"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "finally_clause"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "catch_clause"
+                }
+              ]
             }
           ]
         },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1793,7 +1793,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "_expression",

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char **symbol_names;
-  const char **field_names;
+  const char * const *symbol_names;
+  const char * const *field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;


### PR DESCRIPTION
See #23

There's no "inclusive or" in the grammar DSL, so the permutations of `catch` and `finally` are handled case by case.

(I don't know very much about the grammar DSL so if there's a better way to do this I'd be happy to know.)
