### PR TITLE
extract the subscript_expression arguments to a separate node

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -164,7 +164,7 @@ Fields and subscripts
     (parenthesized_expression (field_expression
       (call_expression
         (field_expression
-          (subscript_expression (identifier) (number))
+          (subscript_expression (identifier) (subscript_argument_list (number)))
           (identifier))
         (argument_list))
       (identifier)))

--- a/grammar.js
+++ b/grammar.js
@@ -446,6 +446,10 @@ grammar({
 
     subscript_expression: $ => seq(
       $._primary_expression,
+      $.subscript_argument_list,
+    ),
+
+    subscript_argument_list: $ => seq(
       token.immediate('['),
       sep(',', $._expression),
       optional(','),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1873,6 +1873,15 @@
           "name": "_primary_expression"
         },
         {
+          "type": "SYMBOL",
+          "name": "subscript_argument_list"
+        }
+      ]
+    },
+    "subscript_argument_list": {
+      "type": "SEQ",
+      "members": [
+        {
           "type": "IMMEDIATE_TOKEN",
           "content": {
             "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1743,6 +1743,21 @@
     }
   },
   {
+    "type": "subscript_argument_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "subscript_expression",
     "named": true,
     "fields": {},
@@ -1751,7 +1766,71 @@
       "required": true,
       "types": [
         {
-          "type": "_expression",
+          "type": "array_comprehension_expression",
+          "named": true
+        },
+        {
+          "type": "array_expression",
+          "named": true
+        },
+        {
+          "type": "broadcast_call_expression",
+          "named": true
+        },
+        {
+          "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "character",
+          "named": true
+        },
+        {
+          "type": "command_string",
+          "named": true
+        },
+        {
+          "type": "field_expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "matrix_expression",
+          "named": true
+        },
+        {
+          "type": "operator",
+          "named": true
+        },
+        {
+          "type": "parameterized_identifier",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subscript_argument_list",
+          "named": true
+        },
+        {
+          "type": "subscript_expression",
+          "named": true
+        },
+        {
+          "type": "triple_string",
+          "named": true
+        },
+        {
+          "type": "tuple_expression",
           "named": true
         }
       ]

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char **symbol_names;
-  const char **field_names;
+  const char * const *symbol_names;
+  const char * const *field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;


### PR DESCRIPTION
This is now in `subscript_argument_list`, the name can be bikeshedded, maybe `subscript_list`

This helps defining textobjects for `nvim-treesitter-textobjects`, as otherwise there is no way to distinguished the subscripts the array