### PR TITLE
Update operators and identifiers

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1688,6 +1688,10 @@
         {
           "type": "SYMBOL",
           "name": "_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "operator"
         }
       ]
     },
@@ -1697,10 +1701,6 @@
         {
           "type": "SYMBOL",
           "name": "identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "operator"
         },
         {
           "type": "SYMBOL",
@@ -1781,8 +1781,12 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "+"
+          "type": "SYMBOL",
+          "name": "_comparison_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dotty_operator"
         },
         {
           "type": "SYMBOL",
@@ -1794,7 +1798,19 @@
         },
         {
           "type": "SYMBOL",
+          "name": "_rational_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_bitshift_operator"
+        },
+        {
+          "type": "SYMBOL",
           "name": "_power_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_unary_operator"
         }
       ]
     },
@@ -2056,8 +2072,17 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "_primary_expression"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_primary_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "operator"
+              }
+            ]
           },
           {
             "type": "SYMBOL",
@@ -2404,17 +2429,22 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_assign_operator"
-              },
-              {
-                "type": "STRING",
-                "value": "="
-              }
-            ]
+            "type": "ALIAS",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_assign_operator"
+                },
+                {
+                  "type": "STRING",
+                  "value": "="
+                }
+              ]
+            },
+            "named": true,
+            "value": "operator"
           },
           {
             "type": "CHOICE",
@@ -2446,45 +2476,13 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ">:"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "+"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "-"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "!"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "~"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "¬"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "√"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "∛"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "∜"
-                  }
-                ]
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_unary_operator"
+                },
+                "named": true,
+                "value": "operator"
               },
               {
                 "type": "SYMBOL",
@@ -2504,17 +2502,13 @@
                 "name": "_expression"
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "'"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ".'"
-                  }
-                ]
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "'"
+                },
+                "named": true,
+                "value": "operator"
               }
             ]
           }
@@ -2535,8 +2529,13 @@
                 "name": "_expression"
               },
               {
-                "type": "SYMBOL",
-                "name": "_power_operator"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_power_operator"
+                },
+                "named": true,
+                "value": "operator"
               },
               {
                 "type": "SYMBOL",
@@ -2556,8 +2555,65 @@
                 "name": "_expression"
               },
               {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_rational_operator"
+                },
+                "named": true,
+                "value": "operator"
+              },
+              {
                 "type": "SYMBOL",
-                "name": "_times_operator"
+                "name": "_expression"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 24,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_bitshift_operator"
+                },
+                "named": true,
+                "value": "operator"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 22,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_times_operator"
+                },
+                "named": true,
+                "value": "operator"
               },
               {
                 "type": "SYMBOL",
@@ -2577,17 +2633,48 @@
                 "name": "_expression"
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "+"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_plus_operator"
-                  }
-                ]
+                "type": "ALIAS",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "+"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_plus_operator"
+                    }
+                  ]
+                },
+                "named": true,
+                "value": "operator"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 20,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_dotty_operator"
+                },
+                "named": true,
+                "value": "operator"
               },
               {
                 "type": "SYMBOL",
@@ -2607,8 +2694,13 @@
                 "name": "_expression"
               },
               {
-                "type": "SYMBOL",
-                "name": "_arrow_operator"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_arrow_operator"
+                },
+                "named": true,
+                "value": "operator"
               },
               {
                 "type": "SYMBOL",
@@ -2628,8 +2720,13 @@
                 "name": "_expression"
               },
               {
-                "type": "STRING",
-                "value": "<|"
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "<|"
+                },
+                "named": true,
+                "value": "operator"
               },
               {
                 "type": "SYMBOL",
@@ -2649,8 +2746,13 @@
                 "name": "_expression"
               },
               {
-                "type": "STRING",
-                "value": "|>"
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "|>"
+                },
+                "named": true,
+                "value": "operator"
               },
               {
                 "type": "SYMBOL",
@@ -2670,21 +2772,26 @@
                 "name": "_expression"
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "in"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "isa"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_comparison_operator"
-                  }
-                ]
+                "type": "ALIAS",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "in"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "isa"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_comparison_operator"
+                    }
+                  ]
+                },
+                "named": true,
+                "value": "operator"
               },
               {
                 "type": "SYMBOL",
@@ -2704,8 +2811,13 @@
                 "name": "_expression"
               },
               {
-                "type": "STRING",
-                "value": "||"
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "||"
+                },
+                "named": true,
+                "value": "operator"
               },
               {
                 "type": "SYMBOL",
@@ -2725,8 +2837,13 @@
                 "name": "_expression"
               },
               {
-                "type": "STRING",
-                "value": "&&"
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "&&"
+                },
+                "named": true,
+                "value": "operator"
               },
               {
                 "type": "SYMBOL",
@@ -3379,11 +3496,8 @@
       ]
     },
     "identifier": {
-      "type": "TOKEN",
-      "content": {
-        "type": "PATTERN",
-        "value": "[_a-zA-ZͰ-ϿĀ-ſ∇][^\"'`\\s\\.\\-\\[\\],;:(){}&|$←→↔↚↛↞↠↢↣↦↤↮⇎⇍⇏⇐⇒⇔⇴⇶⇷⇸⇹⇺⇻⇼⇽⇾⇿⟵⟶⟷⟹⟺⟻⟼⟽⟾⟿⤀⤁⤂⤃⤄⤅⤆⤇⤌⤍⤎⤏⤐⤑⤔⤕⤖⤗⤘⤝⤞⤟⤠⥄⥅⥆⥇⥈⥊⥋⥎⥐⥒⥓⥖⥗⥚⥛⥞⥟⥢⥤⥦⥧⥨⥩⥪⥫⥬⥭⥰⧴⬱⬰⬲⬳⬴⬵⬶⬷⬸⬹⬺⬻⬼⬽⬾⬿⭀⭁⭂⭃⭄⭇⭈⭉⭊⭋⭌￩￫⇜⇝↜↝↩↪↫↬↼↽⇀⇁⇄⇆⇇⇉⇋⇌⇚⇛⇠⇢=+==*=/=//=|=|^=÷=%=<<=>>=>>>=||=|&=⊻=≔⩴≕><>=≥<=≤=====≡=≠==≢∈∉∋∌⊆⊈⊂⊄⊊∝∊∍∥∦∷∺∻∽∾≁≃≂≄≅≆≇≈≉≊≋≌≍≎≐≑≒≓≖≗≘≙≚≛≜≝≞≟≣≦≧≨≩≪≫≬≭≮≯≰≱≲≳≴≵≶≷≸≹≺≻≼≽≾≿⊀⊁⊃⊅⊇⊉⊋⊏⊐⊑⊒⊜⊩⊬⊮⊰⊱⊲⊳⊴⊵⊶⊷⋍⋐⋑⋕⋖⋗⋘⋙⋚⋛⋜⋝⋞⋟⋠⋡⋢⋣⋤⋥⋦⋧⋨⋩⋪⋫⋬⋭⋲⋳⋴⋵⋶⋷⋸⋹⋺⋻⋼⋽⋾⋿⟈⟉⟒⦷⧀⧁⧡⧣⧤⧥⩦⩧⩪⩫⩬⩭⩮⩯⩰⩱⩲⩳⩵⩶⩷⩸⩹⩺⩻⩼⩽⩾⩿⪀⪁⪂⪃⪄⪅⪆⪇⪈⪉⪊⪋⪌⪍⪎⪏⪐⪑⪒⪓⪔⪕⪖⪗⪘⪙⪚⪛⪜⪝⪞⪟⪠⪡⪢⪣⪤⪥⪦⪧⪨⪩⪪⪫⪬⪭⪮⪯⪰⪱⪲⪳⪴⪵⪶⪷⪸⪹⪺⪻⪼⪽⪾⪿⫀⫁⫂⫃⫄⫅⫆⫇⫈⫉⫊⫋⫌⫍⫎⫏⫐⫑⫒⫓⫔⫕⫖⫗⫘⫙⫷⫸⫹⫺⊢⊣⟂+|||⊕⊖⊞⊟|++|∪∨⊔±∓∔∸≂≏⊎⊻⊽⋎⋓⧺⧻⨈⨢⨣⨤⨥⨦⨧⨨⨩⨪⨫⨬⨭⨮⨹⨺⩁⩂⩅⩊⩌⩏⩐⩒⩔⩖⩗⩛⩝⩡⩢⩣^↑↓⇵⟰⟱⤈⤉⤊⤋⤒⤓⥉⥌⥍⥏⥑⥔⥕⥘⥙⥜⥝⥠⥡⥣⥥⥮⥯￪￬*/÷%&⋅∘×\\\\∩∧⊗⊘⊙⊚⊛⊠⊡⊓∗∙∤⅋≀⊼⋄⋆⋇⋉⋊⋋⋌⋏⋒⟑⦸⦼⦾⦿⧶⧷⨇⨰⨱⨲⨳⨴⨵⨶⨷⨸⨻⨼⨽⩀⩃⩄⩋⩍⩎⩑⩓⩕⩘⩚⩜⩞⩟⩠⫛⊍▷⨝⟕⟖⟗]*"
-      }
+      "type": "PATTERN",
+      "value": "[_\\p{L}\\p{Nl}∇][^\"'`\\s\\.\\-\\[\\],;:(){}&$=+==*=/=//=\\\\=^=÷=%=<<=>>=>>>=|=&=⊻=≔⩴≕←→↔↚↛↞↠↢↣↦↤↮⇎⇍⇏⇐⇒⇔⇴⇶⇷⇸⇹⇺⇻⇼⇽⇾⇿⟵⟶⟷⟹⟺⟻⟼⟽⟾⟿⤀⤁⤂⤃⤄⤅⤆⤇⤌⤍⤎⤏⤐⤑⤔⤕⤖⤗⤘⤝⤞⤟⤠⥄⥅⥆⥇⥈⥊⥋⥎⥐⥒⥓⥖⥗⥚⥛⥞⥟⥢⥤⥦⥧⥨⥩⥪⥫⥬⥭⥰⧴⬱⬰⬲⬳⬴⬵⬶⬷⬸⬹⬺⬻⬼⬽⬾⬿⭀⭁⭂⭃⭄⭇⭈⭉⭊⭋⭌￩￫⇜⇝↜↝↩↪↫↬↼↽⇀⇁⇄⇆⇇⇉⇋⇌⇚⇛⇠⇢><>=≥<=≤=====≡=≠==≢∈∉∋∌⊆⊈⊂⊄⊊∝∊∍∥∦∷∺∻∽∾≁≃≂≄≅≆≇≈≉≊≋≌≍≎≐≑≒≓≖≗≘≙≚≛≜≝≞≟≣≦≧≨≩≪≫≬≭≮≯≰≱≲≳≴≵≶≷≸≹≺≻≼≽≾≿⊀⊁⊃⊅⊇⊉⊋⊏⊐⊑⊒⊜⊩⊬⊮⊰⊱⊲⊳⊴⊵⊶⊷⋍⋐⋑⋕⋖⋗⋘⋙⋚⋛⋜⋝⋞⋟⋠⋡⋢⋣⋤⋥⋦⋧⋨⋩⋪⋫⋬⋭⋲⋳⋴⋵⋶⋷⋸⋹⋺⋻⋼⋽⋾⋿⟈⟉⟒⦷⧀⧁⧡⧣⧤⧥⩦⩧⩪⩫⩬⩭⩮⩯⩰⩱⩲⩳⩵⩶⩷⩸⩹⩺⩻⩼⩽⩾⩿⪀⪁⪂⪃⪄⪅⪆⪇⪈⪉⪊⪋⪌⪍⪎⪏⪐⪑⪒⪓⪔⪕⪖⪗⪘⪙⪚⪛⪜⪝⪞⪟⪠⪡⪢⪣⪤⪥⪦⪧⪨⪩⪪⪫⪬⪭⪮⪯⪰⪱⪲⪳⪴⪵⪶⪷⪸⪹⪺⪻⪼⪽⪾⪿⫀⫁⫂⫃⫄⫅⫆⫇⫈⫉⫊⫋⫌⫍⫎⫏⫐⫑⫒⫓⫔⫕⫖⫗⫘⫙⫷⫸⫹⫺⊢⊣⟂…⁝⋮⋱⋰⋯+|⊕⊖⊞⊟++∪∨⊔±∓∔∸≂≏⊎⊻⊽⋎⋓⧺⧻⨈⨢⨣⨤⨥⨦⨧⨨⨩⨪⨫⨬⨭⨮⨹⨺⩁⩂⩅⩊⩌⩏⩐⩒⩔⩖⩗⩛⩝⩡⩢⩣*/÷%&⋅∘×\\\\∩∧⊗⊘⊙⊚⊛⊠⊡⊓∗∙∤⅋≀⊼⋄⋆⋇⋉⋊⋋⋌⋏⋒⟑⦸⦼⦾⦿⧶⧷⨇⨰⨱⨲⨳⨴⨵⨶⨷⨸⨻⨼⨽⩀⩃⩄⩋⩍⩎⩑⩓⩕⩘⩚⩜⩞⩟⩠⫛⊍▷⨝⟕⟖⟗<<>>>>>^↑↓⇵⟰⟱⤈⤉⤊⤋⤒⤓⥉⥌⥍⥏⥑⥔⥕⥘⥙⥜⥝⥠⥡⥣⥥⥮⥯￪￬]*"
     },
     "_literal": {
       "type": "CHOICE",
@@ -3852,6 +3966,63 @@
         }
       ]
     },
+    "_unary_operator": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "+"
+              },
+              {
+                "type": "STRING",
+                "value": "-"
+              },
+              {
+                "type": "STRING",
+                "value": "!"
+              },
+              {
+                "type": "STRING",
+                "value": "~"
+              },
+              {
+                "type": "STRING",
+                "value": "¬"
+              },
+              {
+                "type": "STRING",
+                "value": "√"
+              },
+              {
+                "type": "STRING",
+                "value": "∛"
+              },
+              {
+                "type": "STRING",
+                "value": "∜"
+              }
+            ]
+          }
+        ]
+      }
+    },
     "_power_operator": {
       "type": "TOKEN",
       "content": {
@@ -3995,6 +4166,72 @@
               {
                 "type": "STRING",
                 "value": "￬"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_bitshift_operator": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "<<"
+              },
+              {
+                "type": "STRING",
+                "value": ">>"
+              },
+              {
+                "type": "STRING",
+                "value": ">>>"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_rational_operator": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "//"
               }
             ]
           }
@@ -4367,7 +4604,7 @@
                   },
                   {
                     "type": "STRING",
-                    "value": "|||"
+                    "value": "|"
                   },
                   {
                     "type": "STRING",
@@ -4387,7 +4624,7 @@
                   },
                   {
                     "type": "STRING",
-                    "value": "|++|"
+                    "value": "++"
                   },
                   {
                     "type": "STRING",
@@ -4588,18 +4825,14 @@
         ]
       }
     },
-    "_arrow_operator": {
+    "_dotty_operator": {
       "type": "TOKEN",
       "content": {
         "type": "CHOICE",
         "members": [
           {
             "type": "STRING",
-            "value": "--"
-          },
-          {
-            "type": "STRING",
-            "value": "-->"
+            "value": ".."
           },
           {
             "type": "SEQ",
@@ -4621,571 +4854,27 @@
                 "members": [
                   {
                     "type": "STRING",
-                    "value": "←"
+                    "value": "…"
                   },
                   {
                     "type": "STRING",
-                    "value": "→"
+                    "value": "⁝"
                   },
                   {
                     "type": "STRING",
-                    "value": "↔"
+                    "value": "⋮"
                   },
                   {
                     "type": "STRING",
-                    "value": "↚"
+                    "value": "⋱"
                   },
                   {
                     "type": "STRING",
-                    "value": "↛"
+                    "value": "⋰"
                   },
                   {
                     "type": "STRING",
-                    "value": "↞"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↠"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↢"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↣"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↦"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↤"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↮"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇎"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇍"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇏"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇐"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇒"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇔"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇴"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇶"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇷"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇸"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇹"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇺"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇻"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇼"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇽"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇾"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇿"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟵"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟶"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟷"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟹"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟺"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟻"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟼"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟽"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟾"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟿"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤀"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤁"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤂"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤃"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤄"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤅"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤆"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤇"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤌"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤍"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤎"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤏"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤐"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤑"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤔"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤕"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤖"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤗"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤘"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤝"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤞"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤟"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤠"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥄"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥅"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥆"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥇"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥈"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥊"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥋"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥎"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥐"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥒"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥓"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥖"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥗"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥚"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥛"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥞"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥟"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥢"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥤"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥦"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥧"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥨"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥩"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥪"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥫"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥬"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥭"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥰"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⧴"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬱"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬰"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬲"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬳"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬴"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬵"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬶"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬷"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬸"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬹"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬺"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬻"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬼"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬽"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬾"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬿"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭀"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭁"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭂"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭃"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭄"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭇"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭈"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭉"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭊"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭋"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭌"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "￩"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "￫"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇜"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇝"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↜"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↝"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↩"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↪"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↫"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↬"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↼"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↽"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇀"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇁"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇄"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇆"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇇"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇉"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇋"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇌"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇚"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇛"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇠"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇢"
+                    "value": "⋯"
                   }
                 ]
               }
@@ -5201,11 +4890,11 @@
         "members": [
           {
             "type": "STRING",
-            "value": "|<:|"
+            "value": "<:"
           },
           {
             "type": "STRING",
-            "value": "|>:|"
+            "value": ">:"
           },
           {
             "type": "SEQ",
@@ -6360,6 +6049,616 @@
         ]
       }
     },
+    "_arrow_operator": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "<--"
+          },
+          {
+            "type": "STRING",
+            "value": "-->"
+          },
+          {
+            "type": "STRING",
+            "value": "<-->"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "."
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "←"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "→"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↔"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↚"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↛"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↞"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↠"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↢"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↣"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↦"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↤"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↮"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇎"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇍"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇏"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇐"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇒"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇔"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇴"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇶"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇷"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇸"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇹"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇺"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇻"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇼"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇽"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇾"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇿"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⟵"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⟶"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⟷"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⟹"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⟺"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⟻"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⟼"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⟽"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⟾"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⟿"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤀"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤁"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤂"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤃"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤄"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤅"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤆"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤇"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤌"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤍"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤎"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤏"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤐"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤑"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤔"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤕"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤖"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤗"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤘"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤝"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤞"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤟"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⤠"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥄"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥅"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥆"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥇"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥈"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥊"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥋"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥎"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥐"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥒"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥓"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥖"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥗"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥚"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥛"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥞"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥟"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥢"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥤"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥦"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥧"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥨"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥩"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥪"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥫"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥬"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥭"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⥰"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⧴"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⬱"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⬰"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⬲"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⬳"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⬴"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⬵"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⬶"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⬷"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⬸"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⬹"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⬺"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⬻"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⬼"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⬽"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⬾"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⬿"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⭀"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⭁"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⭂"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⭃"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⭄"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⭇"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⭈"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⭉"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⭊"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⭋"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⭌"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "￩"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "￫"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇜"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇝"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↜"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↝"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↩"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↪"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↫"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↬"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↼"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "↽"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇀"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇁"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇄"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇆"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇇"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇉"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇋"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇌"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇚"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇛"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇠"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⇢"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
     "_assign_operator": {
       "type": "TOKEN",
       "content": {
@@ -6421,7 +6720,7 @@
                   },
                   {
                     "type": "STRING",
-                    "value": "|=|"
+                    "value": "\\="
                   },
                   {
                     "type": "STRING",
@@ -6449,7 +6748,7 @@
                   },
                   {
                     "type": "STRING",
-                    "value": "||=|"
+                    "value": "|="
                   },
                   {
                     "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -424,10 +424,6 @@
           "named": true
         },
         {
-          "type": "operator",
-          "named": true
-        },
-        {
           "type": "parameterized_identifier",
           "named": true
         },
@@ -794,10 +790,6 @@
         },
         {
           "type": "matrix_expression",
-          "named": true
-        },
-        {
-          "type": "operator",
           "named": true
         },
         {
@@ -1983,7 +1975,7 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
         {
@@ -2047,15 +2039,7 @@
     "named": false
   },
   {
-    "type": "!",
-    "named": false
-  },
-  {
     "type": "$",
-    "named": false
-  },
-  {
-    "type": "&&",
     "named": false
   },
   {
@@ -2071,15 +2055,7 @@
     "named": false
   },
   {
-    "type": "+",
-    "named": false
-  },
-  {
     "type": ",",
-    "named": false
-  },
-  {
-    "type": "-",
     "named": false
   },
   {
@@ -2088,10 +2064,6 @@
   },
   {
     "type": ".",
-    "named": false
-  },
-  {
-    "type": ".'",
     "named": false
   },
   {
@@ -2115,19 +2087,11 @@
     "named": false
   },
   {
-    "type": "<|",
-    "named": false
-  },
-  {
     "type": "=",
     "named": false
   },
   {
     "type": "=>",
-    "named": false
-  },
-  {
-    "type": ">:",
     "named": false
   },
   {
@@ -2231,10 +2195,6 @@
     "named": false
   },
   {
-    "type": "isa",
-    "named": false
-  },
-  {
     "type": "let",
     "named": false
   },
@@ -2291,39 +2251,11 @@
     "named": false
   },
   {
-    "type": "|>",
-    "named": false
-  },
-  {
-    "type": "||",
-    "named": false
-  },
-  {
     "type": "}",
     "named": false
   },
   {
-    "type": "~",
-    "named": false
-  },
-  {
-    "type": "¬",
-    "named": false
-  },
-  {
     "type": "∈",
-    "named": false
-  },
-  {
-    "type": "√",
-    "named": false
-  },
-  {
-    "type": "∛",
-    "named": false
-  },
-  {
-    "type": "∜",
     "named": false
   }
 ]

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -175,6 +175,7 @@ end
     (parameter_list (identifier) (optional_parameter (identifier) (identifier)))
     (assignment_expression
       (identifier)
+      (operator)
       (array_expression
         (quote_expression
           (tuple_expression

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1,10 +1,12 @@
-================
-Variables
-================
+==============================
+identifiers
+==============================
 
-w
-w′
-θ
+abc_123_ABC
+_fn!
+ρ; φ; z
+ℝ
+x′
 θ̄
 logŷ
 ϵ
@@ -19,30 +21,12 @@ logŷ
   (identifier)
   (identifier)
   (identifier)
+  (identifier)
+  (identifier)
+  (identifier)
+  (identifier)
   (identifier))
 
-=================
-Assignments
-=================
-
-a = b
-c &= d ÷= e
-a, b = c, d, e
-
----
-
-(source_file
-  (assignment_expression
-    (identifier)
-    (identifier))
-  (assignment_expression
-    (identifier)
-    (assignment_expression
-      (identifier)
-      (identifier)))
-  (assignment_expression
-    (bare_tuple_expression (identifier) (identifier))
-    (bare_tuple_expression (identifier) (identifier) (identifier))))
 
 =================
 Functions
@@ -137,111 +121,19 @@ end
   (macro_expression
     (macro_identifier (identifier))
     (macro_argument_list
-      (binary_expression (identifier) (identifier))))
+      (binary_expression (identifier) (operator) (identifier))))
   (macro_expression
     (macro_identifier (identifier))
     (macro_argument_list
-      (binary_expression (identifier) (identifier))
+      (binary_expression (identifier) (operator) (identifier))
       (string_literal)))
   (macro_expression (macro_identifier (operator)) (macro_argument_list (identifier)))
   (macro_expression
     (macro_identifier (identifier))
     (macro_argument_list
       (string_literal)
-      (compound_expression (assignment_expression (identifier) (identifier))))))
+      (compound_expression (assignment_expression (identifier) (operator) (identifier))))))
 
-=================
-Binary operators
-=================
-
-a → b ⇶ c ⭄ d
-a * b ⦼ c
-a == b
-
----
-
-(source_file
-  (binary_expression
-    (identifier)
-    (binary_expression
-      (identifier)
-      (binary_expression
-        (identifier)
-        (identifier))))
-  (binary_expression
-    (binary_expression
-      (identifier)
-      (identifier))
-    (identifier))
-  (binary_expression
-    (identifier)
-    (identifier)))
-
-===================================
-Binary operators with leading dots
-===================================
-
-a .* b .+ c
-
----
-
-(source_file
-  (binary_expression
-    (binary_expression (identifier) (identifier))
-    (identifier)))
-
-=================
-Unary operators
-=================
-
-+a
--b
-√9
-[a]'
-!(a + b)
-
----
-
-(source_file
-  (unary_expression (identifier))
-  (unary_expression (identifier))
-  (unary_expression (integer_literal))
-  (unary_expression (array_expression (identifier)))
-  (unary_expression
-    (parenthesized_expression (binary_expression (identifier) (identifier)))))
-
-====================
-The ternary operator
-====================
-
-x = batch_size == 1 ?
-  rand(10) :
-  rand(10, batch_size)
-
----
-
-(source_file
-  (assignment_expression
-    (identifier)
-    (ternary_expression
-      (binary_expression (identifier) (integer_literal))
-      (call_expression (identifier) (argument_list (integer_literal)))
-      (call_expression (identifier) (argument_list (integer_literal) (identifier))))))
-
-====================
-Operators as values
-====================
-
-x = +
-print(:)
-foo(^, ÷)
-
----
-
-(source_file
-  (assignment_expression (identifier) (operator))
-  (call_expression (identifier) (argument_list (operator)))
-  (call_expression (identifier) (argument_list (operator) (operator))))
 
 ===========================
 Coefficient expressions
@@ -259,29 +151,39 @@ Coefficient expressions
     (binary_expression
       (binary_expression
         (coefficient_expression (integer_literal) (identifier))
+        (operator)
         (integer_literal))
+      (operator)
       (coefficient_expression (integer_literal) (identifier)))
+    (operator)
     (integer_literal))
   (binary_expression
     (binary_expression
       (binary_expression
         (coefficient_expression (float_literal) (identifier))
+        (operator)
         (integer_literal))
+      (operator)
       (coefficient_expression (float_literal) (identifier)))
+    (operator)
     (integer_literal))
   (binary_expression
     (integer_literal)
+    (operator)
     (coefficient_expression (integer_literal) (identifier)))
   (binary_expression
     (binary_expression
       (binary_expression
         (coefficient_expression
           (integer_literal)
-          (parenthesized_expression (binary_expression (identifier) (integer_literal))))
+          (parenthesized_expression (binary_expression (identifier) (operator) (integer_literal))))
+        (operator)
         (integer_literal))
+      (operator)
       (coefficient_expression
         (integer_literal)
-        (parenthesized_expression (binary_expression (identifier) (integer_literal)))))
+        (parenthesized_expression (binary_expression (identifier) (operator) (integer_literal)))))
+    (operator)
     (integer_literal)))
 
 =================
@@ -313,7 +215,7 @@ Named tuples
 
 (source_file
   (parenthesized_expression
-    (assignment_expression (identifier) (integer_literal)))
+    (assignment_expression (identifier) (operator) (integer_literal)))
   (tuple_expression
     (named_field (identifier) (integer_literal)))
   (tuple_expression
@@ -353,20 +255,6 @@ Matrices
     (matrix_row (integer_literal) (integer_literal))
     (matrix_row (integer_literal) (integer_literal))))
 
-=================
-Pairs
-=================
-
-A(b => c, d => e)
-
----
-
-(source_file
-  (call_expression
-    (identifier)
-    (argument_list
-      (pair_expression (identifier) (identifier))
-      (pair_expression (identifier) (identifier)))))
 
 ====================
 Function expressions
@@ -383,11 +271,15 @@ function () 3 end
 (source_file
   (function_expression
     (identifier)
-    (binary_expression (identifier) (integer_literal)))
+    (binary_expression (identifier) (operator) (integer_literal)))
   (function_expression
     (parameter_list (identifier) (identifier) (identifier))
     (binary_expression
-      (binary_expression (coefficient_expression (integer_literal) (identifier)) (identifier))
+      (binary_expression
+        (coefficient_expression (integer_literal) (identifier))
+        (operator)
+        (identifier))
+      (operator)
       (identifier)))
   (function_expression
     (parameter_list)
@@ -399,7 +291,7 @@ function () 3 end
     (parameter_list)
     (parenthesized_expression
       (call_expression (identifier) (argument_list (float_literal)))
-      (assignment_expression (identifier) (integer_literal))
+      (assignment_expression (identifier) (operator) (integer_literal))
       (identifier))))
 
 ============================

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -94,6 +94,7 @@ band = "Interpol"
   (string_literal)
   (assignment_expression
     (identifier)
+    (operator)
     (string_literal))
   (string_literal
     (string_interpolation (identifier)))
@@ -143,10 +144,12 @@ version = v"1.0"
 (source_file
   (assignment_expression
     (identifier)
+    (operator)
     (prefixed_string_literal 
         prefix: (identifier)))
   (assignment_expression
     (identifier)
+    (operator)
     (prefixed_string_literal 
         prefix: (identifier))))
 
@@ -172,7 +175,7 @@ nested #= comments =# =#
   (line_comment)
   (block_comment)
   (block_comment)
-  (assignment_expression (identifier) (block_comment) (integer_literal))
+  (assignment_expression (identifier) (operator) (block_comment) (integer_literal))
   (block_comment)
   (block_comment))
 

--- a/test/corpus/operators.txt
+++ b/test/corpus/operators.txt
@@ -1,0 +1,255 @@
+==============================
+assignment operators
+==============================
+
+a = b
+a .. b = a * b
+c &= d ÷= e
+tup = 1, 2, 3
+car, cdr... = list
+
+---
+(source_file
+  (assignment_expression
+    (identifier)
+    (operator)
+    (identifier))
+
+  (assignment_expression
+    (binary_expression (identifier) (operator) (identifier))
+    (operator)
+    (binary_expression (identifier) (operator) (identifier)))
+
+  (assignment_expression
+    (identifier)
+    (operator)
+    (assignment_expression
+      (identifier)
+      (operator)
+      (identifier)))
+
+  (assignment_expression
+    (identifier)
+    (operator)
+    (bare_tuple_expression
+      (integer_literal)
+      (integer_literal)
+      (integer_literal)))
+
+  (assignment_expression
+    (bare_tuple_expression
+      (identifier)
+      (spread_expression (identifier)))
+    (operator)
+    (identifier)))
+
+
+==============================
+binary operators
+==============================
+
+a + b
+a ++ 1 × b ⥌ 2 → c
+a:(a // b)
+
+x = A \ (v × w)
+
+a & b | c
+(x >>> 16, x >>> 8, x) .& 0xff
+
+
+---
+(source_file
+  ; Sanity check
+  (binary_expression (identifier) (operator) (identifier))
+
+  ; plus/times/power/arrow
+  ; (→ (++ a (× 1 (⥌ b 2))) c)
+  (binary_expression
+    (binary_expression
+      (identifier)
+      (operator)
+      (binary_expression
+        (integer_literal)
+        (operator)
+        (binary_expression
+          (identifier)
+          (operator)
+          (integer_literal))))
+    (operator)
+    (identifier))
+
+  ; range/rational
+  (range_expression
+    (identifier)
+    (parenthesized_expression
+      (binary_expression
+        (identifier)
+        (operator)
+        (identifier))))
+
+  ; LA
+  (assignment_expression
+    (identifier)
+    (operator)
+    (binary_expression
+      (identifier)
+      (operator)
+      (parenthesized_expression
+        (binary_expression
+          (identifier)
+          (operator)
+          (identifier)))))
+
+  ; bitwise
+  (binary_expression
+    (binary_expression (identifier) (operator) (identifier))
+    (operator)
+    (identifier))
+  (binary_expression
+    (tuple_expression
+      (binary_expression (identifier) (operator) (integer_literal))
+      (binary_expression (identifier) (operator) (integer_literal))
+      (identifier))
+    (operator)
+    (integer_literal)))
+
+
+==============================
+binary comparison operators
+==============================
+
+a === 1
+a! != 0
+
+A ⊆ B ⊆ C
+x ≥ 0 ≥ z
+
+---
+(source_file
+  (binary_expression (identifier) (operator) (integer_literal))
+  (binary_expression (identifier) (operator) (integer_literal))
+
+  ; Chained comparisons are parsed as a single expression in Julia.
+  ; So this isn't 100% correct.
+  (binary_expression
+    (binary_expression
+      (identifier)
+      (operator)
+      (identifier))
+    (operator)
+    (identifier))
+  (binary_expression
+    (binary_expression
+      (identifier)
+      (operator)
+      (integer_literal))
+    (operator)
+    (identifier)))
+
+==============================
+pair operator
+==============================
+
+Dict(b => c, d => e)
+
+---
+(source_file
+  (call_expression
+    (identifier)
+    (argument_list
+      (pair_expression (identifier) (identifier))
+      (pair_expression (identifier) (identifier)))))
+
+
+==============================
+unary operators
+==============================
+
++a
+-b
+√9
+[a, b]'
+!p === !(p)
+1 ++ +2
+
+---
+(source_file
+  (unary_expression (operator) (identifier))
+  (unary_expression (operator) (identifier))
+  (unary_expression (operator) (integer_literal))
+  (unary_expression (array_expression (identifier) (identifier)) (operator))
+  (binary_expression
+    (unary_expression (operator) (identifier))
+    (operator)
+    (call_expression (operator) (argument_list (identifier))))
+  (binary_expression
+    (integer_literal)
+    (operator)
+    (unary_expression (operator) (integer_literal))))
+
+
+=============================
+operator broadcasting
+=============================
+
+a .* b .+ c
+.~[x]
+
+---
+(source_file
+  (binary_expression
+    (binary_expression (identifier) (operator) (identifier))
+    (operator)
+    (identifier))
+  (unary_expression
+    (operator)
+    (array_expression (identifier))))
+
+
+==============================
+ternary operator
+==============================
+
+x = batch_size == 1 ?
+  rand(10) :
+  rand(10, batch_size)
+
+---
+
+(source_file
+  (assignment_expression
+    (identifier)
+    (operator)
+    (ternary_expression
+      (binary_expression (identifier) (operator) (integer_literal))
+      (call_expression (identifier) (argument_list (integer_literal)))
+      (call_expression (identifier) (argument_list (integer_literal) (identifier))))))
+
+
+==============================
+operators as values
+==============================
+
+x = +
+⪯ = .≤
+print(:)
+foo(^, ÷, -)
+
+---
+(source_file
+  (assignment_expression
+    (identifier)
+    (operator)
+    (operator))
+  (assignment_expression
+    (operator)
+    (operator)
+    (operator))
+  (call_expression
+    (identifier)
+    (argument_list (operator)))
+  (call_expression
+  (identifier)
+  (argument_list (operator) (operator) (operator))))
+

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -78,7 +78,7 @@ while a(); b(); end
 
 (source_file
   (while_statement
-    (binary_expression (identifier) (integer_literal))
+    (binary_expression (identifier) (operator) (integer_literal))
     (call_expression (identifier) (argument_list (identifier)))
     (continue_statement)
     (break_statement))
@@ -100,7 +100,7 @@ return a, b, c
 (source_file
   (return_statement)
   (return_statement (identifier))
-  (return_statement (binary_expression (identifier) (identifier)))
+  (return_statement (binary_expression (identifier) (operator) (identifier)))
   (return_statement (bare_tuple_expression (identifier) (identifier) (identifier))))
 
 ===============================
@@ -147,9 +147,9 @@ end
 
 (source_file
   (quote_statement
-    (assignment_expression (identifier) (integer_literal))
-    (assignment_expression (identifier) (integer_literal))
-    (binary_expression (identifier) (identifier))))
+    (assignment_expression (identifier) (operator) (integer_literal))
+    (assignment_expression (identifier) (operator) (integer_literal))
+    (binary_expression (identifier) (operator) (identifier))))
 
 ===============================
 Try statements


### PR DESCRIPTION
- Add more operator types:
  - Bitshift
  - Rational
  - "Dotty"
- Fix unary operators:
  - Add broadcasting dots
  - Allow unary operators as variables
  - Parse <unary-op><array> as a unary_expression (not an index expression)
- Fix pipe typos (femtolisp uses pipes as raw symbol delimiters).
- Simplify `binary_expression` rule.
- Make assignment, binary and unary operators visible. Operators that have their own rules (pair, range) are not made visible.
- Use unicode categories instead of character ranges for valid identifiers. It allows more characters, and removes some invalid ones.
- Add more tests for operators. I put them on a separate file, but I can put them back in the expressions file if that seems better.
- Update other tests. 