### PR TITLE
Add short_function_definition

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -105,7 +105,7 @@ grammar({
   ],
 
   conflicts: $ => [
-    [$._primary_expression, $.short_function_definition],
+    [$._primary_expression, $._short_form_function_definition],
     [$._primary_expression, $.parameter_list],
     [$._primary_expression, $.spread_parameter],
     [$._primary_expression, $.typed_parameter],
@@ -146,11 +146,15 @@ grammar({
       $.struct_definition,
       $.module_definition,
       $.function_definition,
-      $.short_function_definition,
       $.macro_definition
     ),
 
-    function_definition: $ => seq(
+    function_definition: $ => choice(
+      $._long_form_function_definition,
+      $._short_form_function_definition
+    ),
+    
+    _long_form_function_definition: $ => seq(
       'function',
       field('name', $.identifier),
       field('type_parameters', optional($.type_parameter_list)),
@@ -159,7 +163,7 @@ grammar({
       'end'
     ),
 
-    short_function_definition: $ => seq(
+    _short_form_function_definition: $ => seq(
       field('name', $.identifier),
       $._immediate_paren,
       field('parameters', $.parameter_list),

--- a/grammar.js
+++ b/grammar.js
@@ -105,7 +105,7 @@ grammar({
   ],
 
   conflicts: $ => [
-    // Arrow functions vs tuples
+    [$._primary_expression, $.short_function_definition],
     [$._primary_expression, $.parameter_list],
     [$._primary_expression, $.spread_parameter],
     [$._primary_expression, $.typed_parameter],
@@ -146,6 +146,7 @@ grammar({
       $.struct_definition,
       $.module_definition,
       $.function_definition,
+      $.short_function_definition,
       $.macro_definition
     ),
 
@@ -156,6 +157,14 @@ grammar({
       field('parameters', $.parameter_list),
       optional($._expression_list),
       'end'
+    ),
+
+    short_function_definition: $ => seq(
+      field('name', $.identifier),
+      $._immediate_paren,
+      field('parameters', $.parameter_list),
+      '=',
+      $._expression,
     ),
 
     abstract_definition: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -112,6 +112,19 @@
       ]
     },
     "function_definition": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_long_form_function_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_short_form_function_definition"
+        }
+      ]
+    },
+    "_long_form_function_definition": {
       "type": "SEQ",
       "members": [
         {
@@ -165,6 +178,39 @@
         {
           "type": "STRING",
           "value": "end"
+        }
+      ]
+    },
+    "_short_form_function_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_immediate_paren"
+        },
+        {
+          "type": "FIELD",
+          "name": "parameters",
+          "content": {
+            "type": "SYMBOL",
+            "name": "parameter_list"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
         }
       ]
     },
@@ -6838,6 +6884,10 @@
     }
   ],
   "conflicts": [
+    [
+      "_primary_expression",
+      "_short_form_function_definition"
+    ],
     [
       "_primary_expression",
       "parameter_list"

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -159,7 +159,7 @@ end
           (integer_literal))))))
 
 ===============================================
-Short function definition
+Short form function definition
 ===============================================
 
 f(x, y) = x + y
@@ -171,13 +171,13 @@ end
 ---
 
 (source_file
-  (short_function_definition
+  (function_definition
     name: (identifier)
     parameters: (parameter_list 
       (identifier) (identifier))
     (binary_expression 
       (identifier) (operator) (identifier)))
-  (short_function_definition
+  (function_definition
     name: (identifier)
     parameters: (parameter_list 
       (identifier) (identifier))

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -158,6 +158,33 @@ end
           (typed_parameter (identifier) (identifier))
           (integer_literal))))))
 
+===============================================
+Short function definition
+===============================================
+
+f(x, y) = x + y
+
+f(x, y) = begin
+  x + y
+end
+
+---
+
+(source_file
+  (short_function_definition
+    name: (identifier)
+    parameters: (parameter_list 
+      (identifier) (identifier))
+    (binary_expression 
+      (identifier) (operator) (identifier)))
+  (short_function_definition
+    name: (identifier)
+    parameters: (parameter_list 
+      (identifier) (identifier))
+    (compound_expression
+      (binary_expression
+        (identifier) (operator) (identifier)))))
+
 ============================
 Macro definitions
 ======================


### PR DESCRIPTION
This adds the one-line function definition syntax to the grammar. Not sure if this was the right way to solve the conflicts, but it worked for me.

The where syntax (e.g. `f(x::T) where T`) is not yet supported (doesn't work for the standard function definition syntax either).

Example `f(x, y) = x + y`:
```scm
(short_function_definition
  name: (identifier)
  parameters: (parameter_list 
    (identifier) (identifier))
  (binary_expression 
    (identifier) (operator) (identifier)))
```

closes https://github.com/tree-sitter/tree-sitter-julia/issues/36