### PR TITLE
Delete duplicate supertypes definition

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -83,13 +83,6 @@ grammar({
     $._statement,
   ],
 
-  supertypes: $ => [
-    $._statement,
-    $._definition,
-    $._expression,
-    $._primary_expression,
-  ],
-
   externals: $ => [
     $.block_comment,
     $._immediate_paren,


### PR DESCRIPTION
Supertypes was defined twice, this deletes the definition that was overwritten later in the grammar.
Parser stays the same, no need to re-generate.