### PR TITLE
revise do blocks

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -536,6 +536,11 @@ grammar({
 
     do_clause: $ => seq(
       'do',
+      choice(
+        $._terminator, 
+        seq($._expression, $._terminator),
+        seq($.bare_tuple_expression, $._terminator),
+      ),
       $._expression_list,
       'end'
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -536,12 +536,14 @@ grammar({
 
     do_clause: $ => seq(
       'do',
-      choice(
-        $._terminator, 
-        seq($._expression, $._terminator),
-        seq($.bare_tuple_expression, $._terminator),
+      field('parameters',
+        choice(
+          $._terminator,
+          seq($._expression, optional($._terminator)),
+          seq($.bare_tuple_expression, optional($._terminator)),
+        )
       ),
-      $._expression_list,
+      optional($._expression_list),
       'end'
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2366,6 +2366,41 @@
           "value": "do"
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_terminator"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_terminator"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "bare_tuple_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_terminator"
+                }
+              ]
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "_expression_list"
         },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2366,43 +2366,71 @@
           "value": "do"
         },
         {
+          "type": "FIELD",
+          "name": "parameters",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_terminator"
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_terminator"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "bare_tuple_expression"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_terminator"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
           "type": "CHOICE",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_terminator"
+              "name": "_expression_list"
             },
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_terminator"
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "bare_tuple_expression"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_terminator"
-                }
-              ]
+              "type": "BLANK"
             }
           ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression_list"
         },
         {
           "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -664,10 +664,33 @@
   {
     "type": "do_clause",
     "named": true,
-    "fields": {},
+    "fields": {
+      "parameters": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "\n",
+            "named": false
+          },
+          {
+            "type": ";",
+            "named": false
+          },
+          {
+            "type": "_expression",
+            "named": true
+          },
+          {
+            "type": "bare_tuple_expression",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "_expression",

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char * const *symbol_names;
-  const char * const *field_names;
+  const char **symbol_names;
+  const char **field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
@@ -123,7 +123,6 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
-  const TSStateId *primary_state_ids;
 };
 
 /*

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -328,6 +328,20 @@ end
 (source_file (call_expression (identifier) (argument_list) (do_clause (integer_literal))))
 
 ============================
+Do expressions (no arg, semicolon)
+============================
+
+f() do ; 
+  5
+end 
+
+---
+
+(source_file (call_expression (identifier) (argument_list) (do_clause (integer_literal))))
+
+
+
+============================
 Do expressions (one arg)
 ============================
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -314,3 +314,40 @@ Generator expressions
     (call_expression (identifier) (argument_list (identifier) (identifier)))
     (for_clause (for_binding (identifier) (identifier)))
     (for_clause (for_binding (identifier) (identifier)))))
+    
+============================
+Do expressions (no arg)
+============================
+
+f() do 
+  5
+end 
+
+---
+
+(source_file (call_expression (identifier) (argument_list) (do_clause (integer_literal))))
+
+============================
+Do expressions (one arg)
+============================
+
+f() do x 
+  5
+end 
+
+---
+
+(source_file (call_expression (identifier) (argument_list) (do_clause (identifier) (integer_literal))))
+
+============================
+Do expressions (multiple arg)
+============================
+
+f() do x, y 
+  5
+end 
+
+---
+
+(source_file (call_expression (identifier) (argument_list) (do_clause (bare_tuple_expression (identifier) (identifier)) (integer_literal))))
+

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -349,9 +349,16 @@ f() do x
   5
 end 
 
+f() do x x end
+
+f() do x end
+
 ---
 
-(source_file (call_expression (identifier) (argument_list) (do_clause (identifier) (integer_literal))))
+(source_file 
+  (call_expression (identifier) (argument_list) (do_clause (identifier) (integer_literal))) 
+  (call_expression (identifier) (argument_list) (do_clause (identifier) (identifier))) 
+  (call_expression (identifier) (argument_list) (do_clause (identifier))))
 
 ============================
 Do expressions (multiple arg)


### PR DESCRIPTION
**What:**
Currently, parsing for `do` blocks is rather confusing, due to the fact that it makes no distinction in the syntax tree between the arguments to the `do`, and the actual expressions which follow it.

In addition, it does not actually permit a terminator to follow the `do`, making it impossible to parse programs which contain `do`-blocks with nullary arguments denoted by a semicolon. For instance:
```
f() do ;
  5
end
```
will not currently parse.

Chiefly, however, the main concern is that the arguments are not separated from the body of the `do`, making it difficult to actually use the produced tree.

**Why:**
We should allow these cases to be parsed, and make the tree easier to work with.