### PR TITLE
Extend generators

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -655,8 +655,10 @@ grammar({
     ),
 
     _comprehension_clause: $ => seq(
+      $.for_clause,
+      optional($._terminator),
       sep1(
-        optional($._terminator), 
+        optional($._terminator),
         choice($.for_clause, $.if_clause)
       ),
       optional($._terminator)

--- a/grammar.js
+++ b/grammar.js
@@ -642,6 +642,7 @@ grammar({
     generator_expression: $ => seq(
       '(',
       $._expression,
+      optional($._terminator),
       $._comprehension_clause,
       ')'
     ),
@@ -654,22 +655,22 @@ grammar({
     ),
 
     _comprehension_clause: $ => seq(
-      $.for_clause,
-      repeat(choice(
-        $.for_clause,
-        $.if_clause
-      ))
+      sep1(
+        optional($._terminator), 
+        choice($.for_clause, $.if_clause)
+      ),
+      optional($._terminator)
     ),
 
-    if_clause: $ => seq(
+    if_clause: $ => prec(1, seq(
       'if',
       $._expression
-    ),
+    )),
 
-    for_clause: $ => seq(
+    for_clause: $ => prec(1, seq(
       'for',
       sep1(',', $.for_binding)
-    ),
+    )),
 
     for_binding: $ => seq(
       choice($.identifier, $.tuple_expression),

--- a/package.json
+++ b/package.json
@@ -10,15 +10,16 @@
   "author": "Max Brunsfeld",
   "license": "MIT",
   "dependencies": {
-    "nan": "^2.14.0"
+    "nan": "^2.16.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.19.1"
+    "tree-sitter-cli": "^0.19.5"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",
     "test": "tree-sitter test && script/parse-examples",
-    "test-windows": "tree-sitter test"
+    "test-windows": "tree-sitter test",
+    "install": "node-gyp rebuild"
   },
   "tree-sitter": [
     {
@@ -27,5 +28,18 @@
       ],
       "scope": "source.julia"
     }
-  ]
+  ],
+  "gypfile": true,
+  "directories": {
+    "example": "examples",
+    "test": "test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tree-sitter/tree-sitter-julia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/tree-sitter/tree-sitter-julia/issues"
+  },
+  "homepage": "https://github.com/tree-sitter/tree-sitter-julia#readme"
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3200,6 +3200,22 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "SYMBOL",
+          "name": "for_clause"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_terminator"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SEQ",
           "members": [
             {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3154,6 +3154,18 @@
           "name": "_expression"
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_terminator"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "_comprehension_clause"
         },
@@ -3188,53 +3200,20 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "for_clause"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "for_clause"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "if_clause"
-              }
-            ]
-          }
-        }
-      ]
-    },
-    "if_clause": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "if"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
-        }
-      ]
-    },
-    "for_clause": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "for"
-        },
-        {
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "for_binding"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "for_clause"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "if_clause"
+                }
+              ]
             },
             {
               "type": "REPEAT",
@@ -3242,19 +3221,103 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "STRING",
-                    "value": ","
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_terminator"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "for_binding"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "for_clause"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "if_clause"
+                      }
+                    ]
                   }
                 ]
               }
             }
           ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_terminator"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
+    },
+    "if_clause": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "if"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        ]
+      }
+    },
+    "for_clause": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "for"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "for_binding"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "for_binding"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
     },
     "for_binding": {
       "type": "SEQ",

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char * const *symbol_names;
-  const char * const *field_names;
+  const char **symbol_names;
+  const char **field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
@@ -123,7 +123,6 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
-  const TSStateId *primary_state_ids;
 };
 
 /*

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -314,3 +314,24 @@ Generator expressions
     (call_expression (identifier) (argument_list (identifier) (identifier)))
     (for_clause (for_binding (identifier) (identifier)))
     (for_clause (for_binding (identifier) (identifier)))))
+
+============================
+Generator expressions with weird spacing
+============================
+
+(c
+ for x in [1, 2]
+ if true
+) 
+(c
+ for x in [1, 2]
+ if true)
+(c
+ for x in [1, 2] if true)
+
+---
+
+(source_file 
+  (generator_expression (identifier) (for_clause (for_binding (identifier) (array_expression (integer_literal) (integer_literal)))) (if_clause (identifier))) 
+  (generator_expression (identifier) (for_clause (for_binding (identifier) (array_expression (integer_literal) (integer_literal)))) (if_clause (identifier))) 
+  (generator_expression (identifier) (for_clause (for_binding (identifier) (array_expression (integer_literal) (integer_literal)))) (if_clause (identifier))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -319,6 +319,12 @@ Generator expressions
 Generator expressions with weird spacing
 ============================
 
+(c for x in [1, 2] 
+  if true)
+
+(c for x in [1, 2] 
+  if true
+)
 (c
  for x in [1, 2]
  if true
@@ -328,10 +334,16 @@ Generator expressions with weird spacing
  if true)
 (c
  for x in [1, 2] if true)
+(c
+ for x in [1, 2] if true
+)
 
 ---
 
 (source_file 
+  (generator_expression (identifier) (for_clause (for_binding (identifier) (array_expression (integer_literal) (integer_literal)))) (if_clause (identifier))) 
+  (generator_expression (identifier) (for_clause (for_binding (identifier) (array_expression (integer_literal) (integer_literal)))) (if_clause (identifier))) 
+  (generator_expression (identifier) (for_clause (for_binding (identifier) (array_expression (integer_literal) (integer_literal)))) (if_clause (identifier))) 
   (generator_expression (identifier) (for_clause (for_binding (identifier) (array_expression (integer_literal) (integer_literal)))) (if_clause (identifier))) 
   (generator_expression (identifier) (for_clause (for_binding (identifier) (array_expression (integer_literal) (integer_literal)))) (if_clause (identifier))) 
   (generator_expression (identifier) (for_clause (for_binding (identifier) (array_expression (integer_literal) (integer_literal)))) (if_clause (identifier))))


### PR DESCRIPTION
**What:**
Currently, generators are only limitedly supported. We don't allow newlines between clauses of the comprehension, so things like
```
(x for z in [1,2] if true)
```
parse fine, but if you change it to any of the following:
```
(c
 for x in [1, 2]
 if true
) 
(c
 for x in [1, 2]
 if true)
(c
 for x in [1, 2] if true)
(c
 for x in [1, 2] if true
)
```
it breaks.

**Why:**
We should do this, because this actually happens.

**How:**
Added some extra optional terminators. These should allow generous use of newlines and semicolons.

I also needed to add precedence to `for_clause` and `if_clause` over `for_statement` and `if_statement`. This was so generators would not parse as parenthesized expressions containing `for` statements, and related.