### PR TITLE
Improve block statements and import rules

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -128,9 +128,9 @@ grammar({
   ],
 
   rules: {
-    source_file: $ => optional($._expression_list),
+    source_file: $ => optional($._block),
 
-    _expression_list: $ => seq(
+    _block: $ => seq(
       sep1($._terminator, choice(
         $._expression,
         $.assignment_expression,
@@ -155,7 +155,7 @@ grammar({
       choice('module', 'baremodule'),
       field('name', $.identifier),
       optional($._terminator),
-      optional($._expression_list),
+      optional($._block),
       'end'
     ),
 
@@ -185,7 +185,7 @@ grammar({
       field('type_parameters', optional($.type_parameter_list)),
       optional($.subtype_clause),
       optional($._terminator),
-      optional($._expression_list),
+      optional($._block),
       'end'
     ),
 
@@ -199,7 +199,7 @@ grammar({
             $._function_signature,
             field('parameters', $.parameter_list),
           ),
-          optional($._expression_list),
+          optional($._block),
         ),
         // zero method functions
         field('name', choice(
@@ -251,7 +251,7 @@ grammar({
       )),
       $._immediate_paren,
       field('parameters', $.parameter_list),
-      optional($._expression_list),
+      optional($._block),
       'end'
     ),
 
@@ -335,7 +335,7 @@ grammar({
       'if',
       field('condition', $._expression),
       optional($._terminator),
-      optional($._expression_list),
+      optional($._block),
       field('alternative', repeat($.elseif_clause)),
       field('alternative', optional($.else_clause)),
       'end'
@@ -345,17 +345,17 @@ grammar({
       'elseif',
       field('condition', $._expression),
       optional($._terminator),
-      optional($._expression_list)
+      optional($._block)
     ),
 
     else_clause: $ => seq(
       'else',
-      optional($._expression_list)
+      optional($._block)
     ),
 
     try_statement: $ => seq(
       'try',
-      optional($._expression_list),
+      optional($._block),
       optional($.catch_clause),
       optional($.finally_clause),
       'end'
@@ -365,20 +365,20 @@ grammar({
       'catch',
       optional($.identifier),
       optional($._terminator),
-      optional($._expression_list),
+      optional($._block),
     )),
 
     finally_clause: $ => seq(
       'finally',
       optional($._terminator),
-      optional($._expression_list),
+      optional($._block),
     ),
 
     for_statement: $ => seq(
       'for',
       sep1(',', $.for_binding),
       optional($._terminator),
-      optional($._expression_list),
+      optional($._block),
       'end'
     ),
 
@@ -386,7 +386,7 @@ grammar({
       'while',
       field('condition', $._expression),
       optional($._terminator),
-      optional($._expression_list),
+      optional($._block),
       'end'
     ),
 
@@ -406,7 +406,7 @@ grammar({
       'let',
       sep1(',', $.variable_declaration),
       optional($._terminator),
-      optional($._expression_list),
+      optional($._block),
       'end'
     ),
 
@@ -422,7 +422,7 @@ grammar({
 
     quote_statement: $ => seq(
       'quote',
-      optional($._expression_list),
+      optional($._block),
       'end'
     ),
 
@@ -513,7 +513,7 @@ grammar({
     ),
 
     parenthesized_expression: $ => prec(1, seq(
-      '(', choice($._expression_list, $.spread_expression), ')'
+      '(', choice($._block, $.spread_expression), ')'
     )),
 
     field_expression: $ => prec(PREC.dot, seq(
@@ -552,7 +552,7 @@ grammar({
 
     compound_expression: $ => seq(
       'begin',
-      $._expression_list,
+      $._block,
       'end'
     ),
 
@@ -598,7 +598,7 @@ grammar({
     do_clause: $ => seq(
       'do',
       alias($._do_parameter_list, $.parameter_list),
-      optional($._expression_list),
+      optional($._block),
       'end'
     ),
 

--- a/script/known-failures.txt
+++ b/script/known-failures.txt
@@ -19,13 +19,11 @@ examples/Gadfly.jl/test/testscripts/timeseries_day.jl
 examples/Gadfly.jl/test/testscripts/timeseries_year_3.jl
 examples/Gadfly.jl/test/testscripts/unitful_geoms.jl
 examples/Gadfly.jl/test/testscripts/timeseries_year_1.jl
-examples/Gadfly.jl/test/testscripts/percent.jl
 examples/Gadfly.jl/test/testscripts/unitful_color.jl
 examples/Gadfly.jl/test/runtests.jl
 examples/Gadfly.jl/test/regen-precompiles.jl
 examples/Gadfly.jl/test/compare_examples.jl
 examples/Gadfly.jl/src/guide/keys.jl
-examples/Gadfly.jl/src/mapping.jl
 examples/Gadfly.jl/src/statistics.jl
 examples/Gadfly.jl/src/dataframes.jl
 examples/Gadfly.jl/src/scale/scales.jl

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7,14 +7,14 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_expression_list"
+          "name": "_block"
         },
         {
           "type": "BLANK"
         }
       ]
     },
-    "_expression_list": {
+    "_block": {
       "type": "SEQ",
       "members": [
         {
@@ -160,7 +160,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_expression_list"
+              "name": "_block"
             },
             {
               "type": "BLANK"
@@ -360,7 +360,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_expression_list"
+              "name": "_block"
             },
             {
               "type": "BLANK"
@@ -421,7 +421,7 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "_expression_list"
+                      "name": "_block"
                     },
                     {
                       "type": "BLANK"
@@ -639,7 +639,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_expression_list"
+              "name": "_block"
             },
             {
               "type": "BLANK"
@@ -1005,6 +1005,18 @@
       "members": [
         {
           "type": "SYMBOL",
+          "name": "compound_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "quote_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "let_statement"
+        },
+        {
+          "type": "SYMBOL",
           "name": "if_statement"
         },
         {
@@ -1021,18 +1033,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "let_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "const_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "quote_statement"
-        },
-        {
-          "type": "SYMBOL",
           "name": "break_statement"
         },
         {
@@ -1045,11 +1045,127 @@
         },
         {
           "type": "SYMBOL",
-          "name": "import_statement"
+          "name": "const_statement"
         },
         {
           "type": "SYMBOL",
           "name": "export_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "import_statement"
+        }
+      ]
+    },
+    "compound_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "begin"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_block"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "end"
+        }
+      ]
+    },
+    "quote_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "quote"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_block"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "end"
+        }
+      ]
+    },
+    "let_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "let"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "variable_declaration"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "variable_declaration"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_terminator"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_block"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "end"
         }
       ]
     },
@@ -1085,7 +1201,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_expression_list"
+              "name": "_block"
             },
             {
               "type": "BLANK"
@@ -1157,7 +1273,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_expression_list"
+              "name": "_block"
             },
             {
               "type": "BLANK"
@@ -1178,7 +1294,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_expression_list"
+              "name": "_block"
             },
             {
               "type": "BLANK"
@@ -1199,7 +1315,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_expression_list"
+              "name": "_block"
             },
             {
               "type": "BLANK"
@@ -1275,7 +1391,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_expression_list"
+                "name": "_block"
               },
               {
                 "type": "BLANK"
@@ -1309,7 +1425,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_expression_list"
+              "name": "_block"
             },
             {
               "type": "BLANK"
@@ -1367,7 +1483,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_expression_list"
+              "name": "_block"
             },
             {
               "type": "BLANK"
@@ -1412,7 +1528,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_expression_list"
+              "name": "_block"
             },
             {
               "type": "BLANK"
@@ -1466,68 +1582,6 @@
           }
         ]
       }
-    },
-    "let_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "let"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "variable_declaration"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "variable_declaration"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_terminator"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_expression_list"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "end"
-        }
-      ]
     },
     "const_statement": {
       "type": "SEQ",
@@ -1601,162 +1655,12 @@
         ]
       }
     },
-    "quote_statement": {
+    "export_statement": {
       "type": "SEQ",
       "members": [
         {
           "type": "STRING",
-          "value": "quote"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_expression_list"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "end"
-        }
-      ]
-    },
-    "import_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "using"
-            },
-            {
-              "type": "STRING",
-              "value": "import"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_import_list"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "selected_import"
-            }
-          ]
-        }
-      ]
-    },
-    "_import_list": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "STRING",
-                  "value": "."
-                }
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "scoped_identifier"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": ","
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "STRING",
-                        "value": "."
-                      }
-                    },
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "identifier"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "scoped_identifier"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "selected_import": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "STRING",
-            "value": "."
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "scoped_identifier"
-            }
-          ]
-        },
-        {
-          "type": "IMMEDIATE_TOKEN",
-          "content": {
-            "type": "STRING",
-            "value": ":"
-          }
+          "value": "export"
         },
         {
           "type": "PREC_RIGHT",
@@ -1774,6 +1678,10 @@
                   {
                     "type": "SYMBOL",
                     "name": "macro_identifier"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "operator"
                   }
                 ]
               },
@@ -1796,6 +1704,10 @@
                         {
                           "type": "SYMBOL",
                           "name": "macro_identifier"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "operator"
                         }
                       ]
                     }
@@ -1807,22 +1719,183 @@
         }
       ]
     },
-    "export_statement": {
+    "import_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "import"
+            },
+            {
+              "type": "STRING",
+              "value": "using"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_import_list"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "selected_import"
+            }
+          ]
+        }
+      ]
+    },
+    "relative_qualifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "STRING",
+            "value": "."
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "scoped_identifier"
+            }
+          ]
+        }
+      ]
+    },
+    "_importable": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "scoped_identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "relative_qualifier"
+        }
+      ]
+    },
+    "import_alias": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_importable"
+        },
+        {
+          "type": "STRING",
+          "value": "as"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        }
+      ]
+    },
+    "_import_list": {
       "type": "PREC_RIGHT",
       "value": 0,
       "content": {
         "type": "SEQ",
         "members": [
           {
-            "type": "STRING",
-            "value": "export"
-          },
-          {
-            "type": "SEQ",
+            "type": "CHOICE",
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "identifier"
+                "name": "_importable"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "import_alias"
+              }
+            ]
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_importable"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "import_alias"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "selected_import": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_importable"
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": ":"
+          }
+        },
+        {
+          "type": "PREC_RIGHT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_importable"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "import_alias"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "macro_identifier"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "operator"
+                  }
+                ]
               },
               {
                 "type": "REPEAT",
@@ -1834,16 +1907,33 @@
                       "value": ","
                     },
                     {
-                      "type": "SYMBOL",
-                      "name": "identifier"
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_importable"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "import_alias"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "macro_identifier"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "operator"
+                        }
+                      ]
                     }
                   ]
                 }
               }
             ]
           }
-        ]
-      }
+        }
+      ]
     },
     "_expression": {
       "type": "CHOICE",
@@ -1859,10 +1949,6 @@
         {
           "type": "SYMBOL",
           "name": "typed_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "compound_expression"
         },
         {
           "type": "SYMBOL",
@@ -2069,7 +2155,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_expression_list"
+                "name": "_block"
               },
               {
                 "type": "SYMBOL",
@@ -2288,23 +2374,6 @@
         {
           "type": "STRING",
           "value": "}"
-        }
-      ]
-    },
-    "compound_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "begin"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression_list"
-        },
-        {
-          "type": "STRING",
-          "value": "end"
         }
       ]
     },
@@ -2625,7 +2694,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_expression_list"
+              "name": "_block"
             },
             {
               "type": "BLANK"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -74,10 +74,6 @@
         "named": true
       },
       {
-        "type": "compound_expression",
-        "named": true
-      },
-      {
         "type": "false",
         "named": true
       },
@@ -189,6 +185,10 @@
     "subtypes": [
       {
         "type": "break_statement",
+        "named": true
+      },
+      {
+        "type": "compound_statement",
         "named": true
       },
       {
@@ -610,12 +610,12 @@
     }
   },
   {
-    "type": "compound_expression",
+    "type": "compound_statement",
     "named": true,
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "_expression",
@@ -827,6 +827,14 @@
       "types": [
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
+        },
+        {
+          "type": "operator",
           "named": true
         }
       ]
@@ -1213,6 +1221,29 @@
     }
   },
   {
+    "type": "import_alias",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "relative_qualifier",
+          "named": true
+        },
+        {
+          "type": "scoped_identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "import_statement",
     "named": true,
     "fields": {},
@@ -1222,6 +1253,14 @@
       "types": [
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "import_alias",
+          "named": true
+        },
+        {
+          "type": "relative_qualifier",
           "named": true
         },
         {
@@ -1288,7 +1327,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "_expression",
@@ -1794,6 +1833,25 @@
     }
   },
   {
+    "type": "relative_qualifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "scoped_identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "return_statement",
     "named": true,
     "fields": {},
@@ -1844,7 +1902,19 @@
           "named": true
         },
         {
+          "type": "import_alias",
+          "named": true
+        },
+        {
           "type": "macro_identifier",
+          "named": true
+        },
+        {
+          "type": "operator",
+          "named": true
+        },
+        {
+          "type": "relative_qualifier",
           "named": true
         },
         {
@@ -2500,6 +2570,10 @@
   },
   {
     "type": "abstract",
+    "named": false
+  },
+  {
+    "type": "as",
     "named": false
   },
   {

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -124,7 +124,7 @@ end
     (macro_identifier (identifier))
     (macro_argument_list
       (string_literal)
-      (compound_expression (assignment_expression (identifier) (operator) (identifier))))))
+      (compound_statement (assignment_expression (identifier) (operator) (identifier))))))
 
 
 ===========================

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -1,141 +1,31 @@
-=================
-If statements
-=================
-
-if a
-  b()
-elseif c
-  d()
-  d()
-else
-  e()
-end
-
-# empty bodies
-if a
-elseif b
-else
-end
-
----
-
-(source_file
-  (if_statement
-    (identifier)
-    (call_expression (identifier) (argument_list))
-    (elseif_clause
-      (identifier)
-      (call_expression (identifier) (argument_list))
-      (call_expression (identifier) (argument_list)))
-    (else_clause
-      (call_expression (identifier) (argument_list))))
-  (line_comment)
-  (if_statement
-    (identifier)
-    (elseif_clause
-      (identifier))
-    (else_clause)))
-
-===============================
-For statements
-===============================
-
-for i in [1, 2, 3]
-  print(i)
-end
-
-for (a, b) in c
-  print(a, b)
-end
-
----
-
-(source_file
-  (for_statement
-    (for_binding
-      (identifier)
-      (array_expression (integer_literal) (integer_literal) (integer_literal)))
-    (call_expression (identifier) (argument_list (identifier))))
-  (for_statement
-    (for_binding
-      (tuple_expression (identifier) (identifier))
-      (identifier))
-    (call_expression (identifier) (argument_list (identifier) (identifier)))))
-
-===============================
-While statements
-===============================
-
-while i < 5
-  print(i)
-  continue
-  break
-end
-
-while a(); b(); end
-
----
-
-(source_file
-  (while_statement
-    (binary_expression (identifier) (operator) (integer_literal))
-    (call_expression (identifier) (argument_list (identifier)))
-    (continue_statement)
-    (break_statement))
-  (while_statement
-    (call_expression (identifier) (argument_list))
-    (call_expression (identifier) (argument_list))))
-
 ==============================
-Return statements
+compound statements
 ==============================
 
-return
-return a
-return a || b
-return a, b, c
+begin
+end
 
----
-
-(source_file
-  (return_statement)
-  (return_statement (identifier))
-  (return_statement (binary_expression (identifier) (operator) (identifier)))
-  (return_statement (bare_tuple_expression (identifier) (identifier) (identifier))))
-
-===============================
-Let statements
-===============================
-
-let var1 = value1, var2, var3 = value3
-    code
+begin
+    foo
+    bar
+    baz
 end
 
 ---
 
 (source_file
-  (let_statement
-    (variable_declaration (identifier) (identifier))
-    (variable_declaration (identifier))
-    (variable_declaration (identifier) (identifier))
+  (compound_statement)
+  (compound_statement
+    (identifier)
+    (identifier)
     (identifier)))
 
-===============================
-Const statements
-===============================
 
-const x, y = 5
+==============================
+quote statements
+==============================
 
----
-
-(source_file
-  (const_statement
-    (variable_declaration (identifier))
-    (variable_declaration (identifier) (integer_literal))))
-
-===============================
-Quote statements
-===============================
+quote end
 
 quote
   x = 1
@@ -146,14 +36,88 @@ end
 ---
 
 (source_file
+  (quote_statement)
   (quote_statement
     (assignment_expression (identifier) (operator) (integer_literal))
     (assignment_expression (identifier) (operator) (integer_literal))
     (binary_expression (identifier) (operator) (identifier))))
 
-===============================
-Try statements
-===============================
+
+==============================
+let statements
+==============================
+
+let
+end
+
+let var1 = value1, var2, var3 = value3
+    code
+end
+
+---
+
+(source_file
+  (let_statement)
+  (let_statement
+    (variable_declaration (identifier) (identifier))
+    (variable_declaration (identifier))
+    (variable_declaration (identifier) (identifier))
+    (identifier)))
+
+
+==============================
+if statements
+==============================
+
+if a
+elseif b
+else
+end
+
+if true 1 else 0 end
+
+if a
+  b()
+elseif c
+  d()
+  d()
+else
+  e()
+end
+
+---
+
+(source_file
+
+  (if_statement
+    (identifier)
+    (elseif_clause
+      (identifier))
+    (else_clause))
+
+  (if_statement
+    (true)
+    (integer_literal)
+    (else_clause
+      (integer_literal)))
+
+  (if_statement
+    (identifier)
+    (call_expression (identifier) (argument_list))
+    (elseif_clause
+      (identifier)
+      (call_expression (identifier) (argument_list))
+      (call_expression (identifier) (argument_list)))
+    (else_clause
+      (call_expression (identifier) (argument_list)))))
+
+
+==============================
+try statements
+==============================
+
+try catch end
+try finally end
 
 try
     sqrt(x)
@@ -171,46 +135,187 @@ end
 
 (source_file
   (try_statement
+    (catch_clause))
+
+  (try_statement
+    (finally_clause))
+
+  (try_statement
     (call_expression (identifier) (argument_list (identifier)))
     (catch_clause
       (call_expression
         (identifier)
         (argument_list
           (call_expression (identifier) (argument_list (identifier) (integer_literal)))))))
+
   (try_statement
     (call_expression (identifier) (argument_list (identifier)))
     (finally_clause
       (call_expression (identifier) (argument_list (identifier))))))
 
-===============================
-Import statements
-===============================
 
-using Lib
-using BigLib: thing1, thing2
-import Base.show
-import .A: @b
-using A, B, C
+==============================
+for statements
+==============================
+
+for x in xs end
+
+for x in xs foo!(x) end
+
+for i in [1, 2, 3]
+  print(i)
+end
+
+for (a, b) in c
+  print(a, b)
+end
 
 ---
 
 (source_file
-  (import_statement (identifier))
-  (import_statement (selected_import (identifier) (identifier) (identifier)))
-  (import_statement (scoped_identifier (identifier) (identifier)))
-  (import_statement (selected_import (identifier) (macro_identifier (identifier))))
-  (import_statement (identifier) (identifier) (identifier)))
+  (for_statement
+    (for_binding
+      (identifier)
+      (identifier)))
+
+  (for_statement
+    (for_binding
+      (identifier)
+      (identifier))
+    (call_expression (identifier) (argument_list (identifier))))
+
+  (for_statement
+    (for_binding
+      (identifier)
+      (array_expression (integer_literal) (integer_literal) (integer_literal)))
+    (call_expression (identifier) (argument_list (identifier))))
+
+  (for_statement
+    (for_binding
+      (tuple_expression (identifier) (identifier))
+      (identifier))
+    (call_expression (identifier) (argument_list (identifier) (identifier)))))
+
+
+==============================
+while statements
+==============================
+
+while true end
+
+while i < 5
+  print(i)
+  continue
+  break
+end
+
+while a(); b(); end
+
+---
+
+(source_file
+  (while_statement (true))
+
+  (while_statement
+    (binary_expression (identifier) (operator) (integer_literal))
+    (call_expression (identifier) (argument_list (identifier)))
+    (continue_statement)
+    (break_statement))
+
+  (while_statement
+    (call_expression (identifier) (argument_list))
+    (call_expression (identifier) (argument_list))))
+
+
+==============================
+return statements
+==============================
+
+return
+return a
+return a || b
+return a, b, c
+
+---
+
+(source_file
+  (return_statement)
+  (return_statement (identifier))
+  (return_statement (binary_expression (identifier) (operator) (identifier)))
+  (return_statement (bare_tuple_expression (identifier) (identifier) (identifier))))
+
 
 ===============================
-Export statements
+Const statements
 ===============================
+
+const x, y = 5
+
+---
+
+(source_file
+  (const_statement
+    (variable_declaration (identifier))
+    (variable_declaration (identifier) (integer_literal))))
+
+
+==============================
+export statements
+==============================
 
 export a
-export a, b, c
+export a, b, +, *
+export @macroMcAtface
 
 ---
 
 (source_file
   (export_statement (identifier))
-  (export_statement (identifier) (identifier) (identifier)))
+  (export_statement (identifier) (identifier) (operator) (operator))
+  (export_statement (macro_identifier (identifier))))
+
+
+==============================
+import statements
+==============================
+
+import Pkg
+
+using Sockets
+
+using ..Foo, ..Bar
+
+import CSV, Chain, DataFrames
+
+import Base: show, @kwdef, +, *
+
+import LinearAlgebra as la
+
+
+---
+
+(source_file
+  ;; Simple import
+  (import_statement (identifier))
+  (import_statement (identifier))
+
+  ;; Relative paths
+  (import_statement
+    (relative_qualifier (identifier))
+    (relative_qualifier (identifier)))
+
+  ;; List import
+  (import_statement (identifier) (identifier) (identifier))
+
+  ;; Selected import
+  (import_statement
+    (selected_import
+      (identifier)
+      (identifier)
+      (macro_identifier (identifier))
+      (operator)
+      (operator)))
+
+  ;; Alias
+  (import_statement (import_alias (identifier) (identifier))))
 


### PR DESCRIPTION
- Rename `_expression_list` to `_block`. "block" is the name used in Julia ASTs. See: https://docs.julialang.org/en/v1/devdocs/ast/#Block-forms
- Rename `compound_expression` to `compound_statement`
- Fix empty compound and let statements
- Fix import/export statements
  - Add relative qualifiers
  - Add import aliases
  - Allow operators and macro identifiers in imports and exports
- Update tests

---
Closes #13, closes #15, and closes #58 (duplicate)
Closes #28
Closes #59