### PR TITLE
Refactor primary expressions

### DIFF
--- a/script/known-failures.txt
+++ b/script/known-failures.txt
@@ -1,15 +1,9 @@
-examples/Flux.jl/test/cuda/cuda.jl
 examples/Flux.jl/src/losses/utils.jl
 examples/Flux.jl/src/layers/conv.jl
 examples/Flux.jl/src/layers/basic.jl
-examples/Flux.jl/src/layers/recurrent.jl
 examples/Flux.jl/src/optimise/optimisers.jl
-examples/Flux.jl/src/utils.jl
 examples/Flux.jl/src/cuda/cudnn.jl
 examples/Flux.jl/src/cuda/curnn.jl
-examples/Flux.jl/src/functor.jl
-examples/Flux.jl/src/onehot.jl
-examples/Flux.jl/src/data/Data.jl
 examples/Flux.jl/src/zeros.jl
 examples/Gadfly.jl/test/testscripts/timeseries_month.jl
 examples/Gadfly.jl/test/testscripts/contour.jl
@@ -23,7 +17,6 @@ examples/Gadfly.jl/test/testscripts/unitful_color.jl
 examples/Gadfly.jl/test/runtests.jl
 examples/Gadfly.jl/test/regen-precompiles.jl
 examples/Gadfly.jl/test/compare_examples.jl
-examples/Gadfly.jl/src/guide/keys.jl
 examples/Gadfly.jl/src/statistics.jl
 examples/Gadfly.jl/src/dataframes.jl
 examples/Gadfly.jl/src/scale/scales.jl
@@ -49,7 +42,6 @@ examples/Gadfly.jl/src/aesthetics.jl
 examples/Gadfly.jl/src/misc.jl
 examples/Gadfly.jl/src/color_misc.jl
 examples/Gadfly.jl/src/guide.jl
-examples/Gadfly.jl/src/theme.jl
 examples/Mocha.jl/tools/image-classifier.jl
 examples/Mocha.jl/test/layers/power.jl
 examples/Mocha.jl/test/layers/softmax.jl
@@ -69,7 +61,6 @@ examples/Mocha.jl/test/layers/concat.jl
 examples/Mocha.jl/test/layers/convolution.jl
 examples/Mocha.jl/test/utils/ref-count.jl
 examples/Mocha.jl/examples/mnist/mnist-demo.jl
-examples/Mocha.jl/examples/test-wasserstein.jl
 examples/Mocha.jl/examples/cifar10/convert.jl
 examples/Mocha.jl/benchmarks/parallel-loop/parallel-pool-module.jl
 examples/Mocha.jl/src/parameter.jl
@@ -145,13 +136,11 @@ examples/Mocha.jl/src/compatibility.jl
 examples/Mocha.jl/src/backend.jl
 examples/Mocha.jl/src/data-transformers.jl
 examples/IJulia.jl/test/comm.jl
-examples/IJulia.jl/deps/kspec.jl
 examples/IJulia.jl/deps/build.jl
 examples/IJulia.jl/src/init.jl
 examples/IJulia.jl/src/stdio.jl
 examples/IJulia.jl/src/magics.jl
 examples/IJulia.jl/src/comm_manager.jl
 examples/IJulia.jl/src/execute_request.jl
-examples/IJulia.jl/src/display.jl
 examples/IJulia.jl/src/handlers.jl
 examples/IJulia.jl/src/IJulia.jl

--- a/script/known-failures.txt
+++ b/script/known-failures.txt
@@ -25,7 +25,6 @@ examples/Gadfly.jl/src/Gadfly.jl
 examples/Gadfly.jl/src/varset.jl
 examples/Gadfly.jl/src/scale.jl
 examples/Gadfly.jl/src/bincount.jl
-examples/Gadfly.jl/src/coord.jl
 examples/Gadfly.jl/src/poetry.jl
 examples/Gadfly.jl/src/ticks.jl
 examples/Gadfly.jl/src/geom/segment.jl

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1940,11 +1940,23 @@
       "members": [
         {
           "type": "SYMBOL",
+          "name": "_definition"
+        },
+        {
+          "type": "SYMBOL",
           "name": "_statement"
         },
         {
           "type": "SYMBOL",
-          "name": "_definition"
+          "name": "_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_primary_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "operator"
         },
         {
           "type": "SYMBOL",
@@ -1965,7 +1977,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "macro_expression"
+          "name": "macrocall_expression"
         },
         {
           "type": "SYMBOL",
@@ -1978,10 +1990,6 @@
         {
           "type": "SYMBOL",
           "name": "ternary_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "generator_expression"
         },
         {
           "type": "SYMBOL",
@@ -1998,26 +2006,6 @@
         {
           "type": "SYMBOL",
           "name": "range_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "quote_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "interpolation_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_primary_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "operator"
         }
       ]
     },
@@ -2026,19 +2014,11 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_quotable"
         },
         {
           "type": "SYMBOL",
-          "name": "array_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "array_comprehension_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "matrix_expression"
+          "name": "broadcast_call_expression"
         },
         {
           "type": "SYMBOL",
@@ -2046,7 +2026,48 @@
         },
         {
           "type": "SYMBOL",
+          "name": "parametrized_type_expression"
+        },
+        {
+          "type": "SYMBOL",
           "name": "field_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "index_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "interpolation_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "quote_expression"
+        }
+      ]
+    },
+    "_quotable": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "array_comprehension_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "array_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "generator_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "matrix_expression"
         },
         {
           "type": "SYMBOL",
@@ -2054,131 +2075,23 @@
         },
         {
           "type": "SYMBOL",
-          "name": "subscript_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "parameterized_identifier"
-        },
-        {
-          "type": "SYMBOL",
           "name": "tuple_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "broadcast_call_expression"
         }
       ]
-    },
-    "bare_tuple_expression": {
-      "type": "PREC",
-      "value": -1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_expression"
-          },
-          {
-            "type": "REPEAT1",
-            "content": {
-              "type": "PREC",
-              "value": -1,
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_expression"
-                  }
-                ]
-              }
-            }
-          }
-        ]
-      }
-    },
-    "operator": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_comparison_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_dotty_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_plus_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_times_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_rational_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_bitshift_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_power_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_unary_operator"
-        }
-      ]
-    },
-    "parenthesized_expression": {
-      "type": "PREC",
-      "value": 1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "("
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_block"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "spread_expression"
-              }
-            ]
-          },
-          {
-            "type": "STRING",
-            "value": ")"
-          }
-        ]
-      }
     },
     "field_expression": {
       "type": "PREC",
-      "value": 28,
+      "value": 27,
       "content": {
         "type": "SEQ",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "_primary_expression"
+            "type": "FIELD",
+            "name": "value",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_primary_expression"
+            }
           },
           {
             "type": "IMMEDIATE_TOKEN",
@@ -2194,21 +2107,16 @@
         ]
       }
     },
-    "subscript_expression": {
+    "index_expression": {
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_primary_expression"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_literal"
-            }
-          ]
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_primary_expression"
+          }
         },
         {
           "type": "IMMEDIATE_TOKEN",
@@ -2268,106 +2176,81 @@
         }
       ]
     },
-    "typed_expression": {
-      "type": "PREC",
-      "value": 27,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
+    "parametrized_type_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
             "type": "SYMBOL",
-            "name": "_expression"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "::"
-              },
-              {
-                "type": "STRING",
-                "value": "<:"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "parameterized_identifier"
-              }
-            ]
+            "name": "_primary_expression"
           }
-        ]
-      }
-    },
-    "parameterized_identifier": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "field_expression"
-            }
-          ]
         },
-        {
-          "type": "SYMBOL",
-          "name": "type_argument_list"
-        }
-      ]
-    },
-    "type_argument_list": {
-      "type": "SEQ",
-      "members": [
         {
           "type": "STRING",
           "value": "{"
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
+              "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "_expression"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_expression"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "subtype_clause"
+                    }
+                  ]
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "_expression"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "subtype_clause"
+                          }
+                        ]
+                      }
+                    ]
+                  }
                 }
               ]
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_expression"
-                      }
-                    ]
-                  }
-                ]
-              }
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
             }
           ]
         },
@@ -2379,7 +2262,7 @@
     },
     "call_expression": {
       "type": "PREC",
-      "value": 26,
+      "value": 25,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2430,7 +2313,7 @@
     },
     "broadcast_call_expression": {
       "type": "PREC",
-      "value": 26,
+      "value": 25,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2477,7 +2360,7 @@
         ]
       }
     },
-    "macro_expression": {
+    "macrocall_expression": {
       "type": "PREC_RIGHT",
       "value": 0,
       "content": {
@@ -2624,6 +2507,10 @@
                           "name": "_implicit_named_field"
                         },
                         {
+                          "type": "SYMBOL",
+                          "name": "spread_expression"
+                        },
+                        {
                           "type": "ALIAS",
                           "content": {
                             "type": "SYMBOL",
@@ -2649,6 +2536,10 @@
                               {
                                 "type": "SYMBOL",
                                 "name": "_implicit_named_field"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "spread_expression"
                               },
                               {
                                 "type": "ALIAS",
@@ -2859,7 +2750,7 @@
     },
     "spread_expression": {
       "type": "PREC",
-      "value": 28,
+      "value": 27,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2936,7 +2827,7 @@
       "members": [
         {
           "type": "PREC",
-          "value": 30,
+          "value": 29,
           "content": {
             "type": "SEQ",
             "members": [
@@ -2958,7 +2849,7 @@
         },
         {
           "type": "PREC",
-          "value": 29,
+          "value": 28,
           "content": {
             "type": "SEQ",
             "members": [
@@ -2985,7 +2876,7 @@
       "members": [
         {
           "type": "PREC_LEFT",
-          "value": 25,
+          "value": 24,
           "content": {
             "type": "SEQ",
             "members": [
@@ -3011,7 +2902,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 23,
+          "value": 22,
           "content": {
             "type": "SEQ",
             "members": [
@@ -3037,7 +2928,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 24,
+          "value": 23,
           "content": {
             "type": "SEQ",
             "members": [
@@ -3063,7 +2954,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 22,
+          "value": 21,
           "content": {
             "type": "SEQ",
             "members": [
@@ -3089,7 +2980,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 21,
+          "value": 20,
           "content": {
             "type": "SEQ",
             "members": [
@@ -3124,7 +3015,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 20,
+          "value": 19,
           "content": {
             "type": "SEQ",
             "members": [
@@ -3369,6 +3260,78 @@
         ]
       }
     },
+    "typed_expression": {
+      "type": "PREC",
+      "value": 26,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "::"
+              },
+              {
+                "type": "STRING",
+                "value": "<:"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "parametrized_type_expression"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "bare_tuple_expression": {
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "PREC",
+              "value": -1,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
     "tuple_expression": {
       "type": "SEQ",
       "members": [
@@ -3563,6 +3526,74 @@
         }
       ]
     },
+    "parenthesized_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "assignment_expression"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ";"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_expression"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "assignment_expression"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
     "array_expression": {
       "type": "SEQ",
       "members": [
@@ -3577,8 +3608,17 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "_expression"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_expression"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "assignment_expression"
+                    }
+                  ]
                 },
                 {
                   "type": "REPEAT",
@@ -3590,8 +3630,17 @@
                         "value": ","
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "_expression"
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "_expression"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "assignment_expression"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -3888,7 +3937,7 @@
     },
     "range_expression": {
       "type": "PREC_LEFT",
-      "value": 20,
+      "value": 19,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3909,7 +3958,7 @@
     },
     "coefficient_expression": {
       "type": "PREC",
-      "value": 26,
+      "value": 25,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3949,7 +3998,7 @@
     },
     "quote_expression": {
       "type": "PREC_LEFT",
-      "value": 19,
+      "value": 29,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3959,14 +4008,14 @@
           },
           {
             "type": "SYMBOL",
-            "name": "_expression"
+            "name": "_quotable"
           }
         ]
       }
     },
     "interpolation_expression": {
       "type": "PREC_LEFT",
-      "value": 19,
+      "value": 29,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3976,7 +4025,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "_expression"
+            "name": "_quotable"
           }
         ]
       }
@@ -4047,7 +4096,44 @@
     },
     "identifier": {
       "type": "PATTERN",
-      "value": "[_\\p{L}\\p{Nl}∇][^\"'`\\s\\.\\-\\[\\],;:(){}&$=+==*=/=//=\\\\=^=÷=%=<<=>>=>>>=|=&=⊻=≔⩴≕←→↔↚↛↞↠↢↣↦↤↮⇎⇍⇏⇐⇒⇔⇴⇶⇷⇸⇹⇺⇻⇼⇽⇾⇿⟵⟶⟷⟹⟺⟻⟼⟽⟾⟿⤀⤁⤂⤃⤄⤅⤆⤇⤌⤍⤎⤏⤐⤑⤔⤕⤖⤗⤘⤝⤞⤟⤠⥄⥅⥆⥇⥈⥊⥋⥎⥐⥒⥓⥖⥗⥚⥛⥞⥟⥢⥤⥦⥧⥨⥩⥪⥫⥬⥭⥰⧴⬱⬰⬲⬳⬴⬵⬶⬷⬸⬹⬺⬻⬼⬽⬾⬿⭀⭁⭂⭃⭄⭇⭈⭉⭊⭋⭌￩￫⇜⇝↜↝↩↪↫↬↼↽⇀⇁⇄⇆⇇⇉⇋⇌⇚⇛⇠⇢><>=≥<=≤=====≡=≠==≢∈∉∋∌⊆⊈⊂⊄⊊∝∊∍∥∦∷∺∻∽∾≁≃≂≄≅≆≇≈≉≊≋≌≍≎≐≑≒≓≖≗≘≙≚≛≜≝≞≟≣≦≧≨≩≪≫≬≭≮≯≰≱≲≳≴≵≶≷≸≹≺≻≼≽≾≿⊀⊁⊃⊅⊇⊉⊋⊏⊐⊑⊒⊜⊩⊬⊮⊰⊱⊲⊳⊴⊵⊶⊷⋍⋐⋑⋕⋖⋗⋘⋙⋚⋛⋜⋝⋞⋟⋠⋡⋢⋣⋤⋥⋦⋧⋨⋩⋪⋫⋬⋭⋲⋳⋴⋵⋶⋷⋸⋹⋺⋻⋼⋽⋾⋿⟈⟉⟒⦷⧀⧁⧡⧣⧤⧥⩦⩧⩪⩫⩬⩭⩮⩯⩰⩱⩲⩳⩵⩶⩷⩸⩹⩺⩻⩼⩽⩾⩿⪀⪁⪂⪃⪄⪅⪆⪇⪈⪉⪊⪋⪌⪍⪎⪏⪐⪑⪒⪓⪔⪕⪖⪗⪘⪙⪚⪛⪜⪝⪞⪟⪠⪡⪢⪣⪤⪥⪦⪧⪨⪩⪪⪫⪬⪭⪮⪯⪰⪱⪲⪳⪴⪵⪶⪷⪸⪹⪺⪻⪼⪽⪾⪿⫀⫁⫂⫃⫄⫅⫆⫇⫈⫉⫊⫋⫌⫍⫎⫏⫐⫑⫒⫓⫔⫕⫖⫗⫘⫙⫷⫸⫹⫺⊢⊣⟂…⁝⋮⋱⋰⋯+|⊕⊖⊞⊟++∪∨⊔±∓∔∸≂≏⊎⊻⊽⋎⋓⧺⧻⨈⨢⨣⨤⨥⨦⨧⨨⨩⨪⨫⨬⨭⨮⨹⨺⩁⩂⩅⩊⩌⩏⩐⩒⩔⩖⩗⩛⩝⩡⩢⩣*/÷%&⋅∘×\\\\∩∧⊗⊘⊙⊚⊛⊠⊡⊓∗∙∤⅋≀⊼⋄⋆⋇⋉⋊⋋⋌⋏⋒⟑⦸⦼⦾⦿⧶⧷⨇⨰⨱⨲⨳⨴⨵⨶⨷⨸⨻⨼⨽⩀⩃⩄⩋⩍⩎⩑⩓⩕⩘⩚⩜⩞⩟⩠⫛⊍▷⨝⟕⟖⟗<<>>>>>^↑↓⇵⟰⟱⤈⤉⤊⤋⤒⤓⥉⥌⥍⥏⥑⥔⥕⥘⥙⥜⥝⥠⥡⥣⥥⥮⥯￪￬]*"
+      "value": "[_\\p{L}\\p{Nl}∇][^\"'`\\s\\.\\-\\[\\],;:(){}&$@=+==*=/=//=\\\\=^=÷=%=<<=>>=>>>=|=&=⊻=≔⩴≕←→↔↚↛↞↠↢↣↦↤↮⇎⇍⇏⇐⇒⇔⇴⇶⇷⇸⇹⇺⇻⇼⇽⇾⇿⟵⟶⟷⟹⟺⟻⟼⟽⟾⟿⤀⤁⤂⤃⤄⤅⤆⤇⤌⤍⤎⤏⤐⤑⤔⤕⤖⤗⤘⤝⤞⤟⤠⥄⥅⥆⥇⥈⥊⥋⥎⥐⥒⥓⥖⥗⥚⥛⥞⥟⥢⥤⥦⥧⥨⥩⥪⥫⥬⥭⥰⧴⬱⬰⬲⬳⬴⬵⬶⬷⬸⬹⬺⬻⬼⬽⬾⬿⭀⭁⭂⭃⭄⭇⭈⭉⭊⭋⭌￩￫⇜⇝↜↝↩↪↫↬↼↽⇀⇁⇄⇆⇇⇉⇋⇌⇚⇛⇠⇢><>=≥<=≤=====≡=≠==≢∈∉∋∌⊆⊈⊂⊄⊊∝∊∍∥∦∷∺∻∽∾≁≃≂≄≅≆≇≈≉≊≋≌≍≎≐≑≒≓≖≗≘≙≚≛≜≝≞≟≣≦≧≨≩≪≫≬≭≮≯≰≱≲≳≴≵≶≷≸≹≺≻≼≽≾≿⊀⊁⊃⊅⊇⊉⊋⊏⊐⊑⊒⊜⊩⊬⊮⊰⊱⊲⊳⊴⊵⊶⊷⋍⋐⋑⋕⋖⋗⋘⋙⋚⋛⋜⋝⋞⋟⋠⋡⋢⋣⋤⋥⋦⋧⋨⋩⋪⋫⋬⋭⋲⋳⋴⋵⋶⋷⋸⋹⋺⋻⋼⋽⋾⋿⟈⟉⟒⦷⧀⧁⧡⧣⧤⧥⩦⩧⩪⩫⩬⩭⩮⩯⩰⩱⩲⩳⩵⩶⩷⩸⩹⩺⩻⩼⩽⩾⩿⪀⪁⪂⪃⪄⪅⪆⪇⪈⪉⪊⪋⪌⪍⪎⪏⪐⪑⪒⪓⪔⪕⪖⪗⪘⪙⪚⪛⪜⪝⪞⪟⪠⪡⪢⪣⪤⪥⪦⪧⪨⪩⪪⪫⪬⪭⪮⪯⪰⪱⪲⪳⪴⪵⪶⪷⪸⪹⪺⪻⪼⪽⪾⪿⫀⫁⫂⫃⫄⫅⫆⫇⫈⫉⫊⫋⫌⫍⫎⫏⫐⫑⫒⫓⫔⫕⫖⫗⫘⫙⫷⫸⫹⫺⊢⊣⟂…⁝⋮⋱⋰⋯+|⊕⊖⊞⊟++∪∨⊔±∓∔∸≂≏⊎⊻⊽⋎⋓⧺⧻⨈⨢⨣⨤⨥⨦⨧⨨⨩⨪⨫⨬⨭⨮⨹⨺⩁⩂⩅⩊⩌⩏⩐⩒⩔⩖⩗⩛⩝⩡⩢⩣*/÷%&⋅∘×\\\\∩∧⊗⊘⊙⊚⊛⊠⊡⊓∗∙∤⅋≀⊼⋄⋆⋇⋉⋊⋋⋌⋏⋒⟑⦸⦼⦾⦿⧶⧷⨇⨰⨱⨲⨳⨴⨵⨶⨷⨸⨻⨼⨽⩀⩃⩄⩋⩍⩎⩑⩓⩕⩘⩚⩜⩞⩟⩠⫛⊍▷⨝⟕⟖⟗<<>>>>>^↑↓⇵⟰⟱⤈⤉⤊⤋⤒⤓⥉⥌⥍⥏⥑⥔⥕⥘⥙⥜⥝⥠⥡⥣⥥⥮⥯￪￬]*"
+    },
+    "operator": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_comparison_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dotty_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_plus_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_times_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_rational_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_bitshift_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_power_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_unary_operator"
+        }
+      ]
     },
     "_literal": {
       "type": "CHOICE",
@@ -7389,40 +7475,36 @@
   ],
   "conflicts": [
     [
-      "_primary_expression",
+      "_quotable",
       "_function_signature"
     ],
     [
-      "_primary_expression",
+      "_quotable",
       "parameter_list"
     ],
     [
-      "_primary_expression",
+      "_quotable",
       "slurp_parameter"
     ],
     [
-      "_primary_expression",
+      "_quotable",
       "typed_parameter"
-    ],
-    [
-      "_primary_expression",
-      "type_parameter_list"
-    ],
-    [
-      "_primary_expression",
-      "constrained_type_parameter"
     ],
     [
       "parameter_list",
       "argument_list"
     ],
     [
-      "_primary_expression",
+      "keyword_parameters",
+      "argument_list"
+    ],
+    [
+      "_quotable",
       "named_field",
       "optional_parameter"
     ],
     [
-      "_primary_expression",
+      "_quotable",
       "named_field"
     ],
     [
@@ -7434,7 +7516,7 @@
       "_implicit_named_field"
     ],
     [
-      "_primary_expression",
+      "_quotable",
       "scoped_identifier"
     ]
   ],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -98,6 +98,10 @@
         "named": true
       },
       {
+        "type": "index_expression",
+        "named": true
+      },
+      {
         "type": "integer_literal",
         "named": true
       },
@@ -106,7 +110,7 @@
         "named": true
       },
       {
-        "type": "macro_expression",
+        "type": "macrocall_expression",
         "named": true
       },
       {
@@ -122,7 +126,7 @@
         "named": true
       },
       {
-        "type": "parameterized_identifier",
+        "type": "parametrized_type_expression",
         "named": true
       },
       {
@@ -151,10 +155,6 @@
       },
       {
         "type": "string_literal",
-        "named": true
-      },
-      {
-        "type": "subscript_expression",
         "named": true
       },
       {
@@ -326,6 +326,10 @@
         {
           "type": "_expression",
           "named": true
+        },
+        {
+          "type": "assignment_expression",
+          "named": true
         }
       ]
     }
@@ -428,11 +432,19 @@
           "named": true
         },
         {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "interpolation_expression",
+          "named": true
+        },
+        {
           "type": "matrix_expression",
           "named": true
         },
         {
-          "type": "parameterized_identifier",
+          "type": "parametrized_type_expression",
           "named": true
         },
         {
@@ -440,7 +452,7 @@
           "named": true
         },
         {
-          "type": "subscript_expression",
+          "type": "quote_expression",
           "named": true
         },
         {
@@ -495,6 +507,14 @@
           "named": true
         },
         {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "interpolation_expression",
+          "named": true
+        },
+        {
           "type": "matrix_expression",
           "named": true
         },
@@ -503,7 +523,7 @@
           "named": true
         },
         {
-          "type": "parameterized_identifier",
+          "type": "parametrized_type_expression",
           "named": true
         },
         {
@@ -511,7 +531,7 @@
           "named": true
         },
         {
-          "type": "subscript_expression",
+          "type": "quote_expression",
           "named": true
         },
         {
@@ -680,7 +700,19 @@
             "named": true
           },
           {
+            "type": "generator_expression",
+            "named": true
+          },
+          {
             "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "index_expression",
+            "named": true
+          },
+          {
+            "type": "interpolation_expression",
             "named": true
           },
           {
@@ -688,7 +720,7 @@
             "named": true
           },
           {
-            "type": "parameterized_identifier",
+            "type": "parametrized_type_expression",
             "named": true
           },
           {
@@ -700,7 +732,7 @@
             "named": true
           },
           {
-            "type": "subscript_expression",
+            "type": "quote_expression",
             "named": true
           },
           {
@@ -843,53 +875,76 @@
   {
     "type": "field_expression",
     "named": true,
-    "fields": {},
+    "fields": {
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "array_comprehension_expression",
+            "named": true
+          },
+          {
+            "type": "array_expression",
+            "named": true
+          },
+          {
+            "type": "broadcast_call_expression",
+            "named": true
+          },
+          {
+            "type": "call_expression",
+            "named": true
+          },
+          {
+            "type": "field_expression",
+            "named": true
+          },
+          {
+            "type": "generator_expression",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "index_expression",
+            "named": true
+          },
+          {
+            "type": "interpolation_expression",
+            "named": true
+          },
+          {
+            "type": "matrix_expression",
+            "named": true
+          },
+          {
+            "type": "parametrized_type_expression",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "quote_expression",
+            "named": true
+          },
+          {
+            "type": "tuple_expression",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
         {
-          "type": "array_comprehension_expression",
-          "named": true
-        },
-        {
-          "type": "array_expression",
-          "named": true
-        },
-        {
-          "type": "broadcast_call_expression",
-          "named": true
-        },
-        {
-          "type": "call_expression",
-          "named": true
-        },
-        {
-          "type": "field_expression",
-          "named": true
-        },
-        {
           "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "matrix_expression",
-          "named": true
-        },
-        {
-          "type": "parameterized_identifier",
-          "named": true
-        },
-        {
-          "type": "parenthesized_expression",
-          "named": true
-        },
-        {
-          "type": "subscript_expression",
-          "named": true
-        },
-        {
-          "type": "tuple_expression",
           "named": true
         }
       ]
@@ -1040,7 +1095,19 @@
             "named": true
           },
           {
+            "type": "generator_expression",
+            "named": true
+          },
+          {
             "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "index_expression",
+            "named": true
+          },
+          {
+            "type": "interpolation_expression",
             "named": true
           },
           {
@@ -1048,7 +1115,7 @@
             "named": true
           },
           {
-            "type": "parameterized_identifier",
+            "type": "parametrized_type_expression",
             "named": true
           },
           {
@@ -1060,7 +1127,7 @@
             "named": true
           },
           {
-            "type": "subscript_expression",
+            "type": "quote_expression",
             "named": true
           },
           {
@@ -1275,6 +1342,84 @@
     }
   },
   {
+    "type": "index_expression",
+    "named": true,
+    "fields": {
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "array_comprehension_expression",
+            "named": true
+          },
+          {
+            "type": "array_expression",
+            "named": true
+          },
+          {
+            "type": "broadcast_call_expression",
+            "named": true
+          },
+          {
+            "type": "call_expression",
+            "named": true
+          },
+          {
+            "type": "field_expression",
+            "named": true
+          },
+          {
+            "type": "generator_expression",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "index_expression",
+            "named": true
+          },
+          {
+            "type": "interpolation_expression",
+            "named": true
+          },
+          {
+            "type": "matrix_expression",
+            "named": true
+          },
+          {
+            "type": "parametrized_type_expression",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "quote_expression",
+            "named": true
+          },
+          {
+            "type": "tuple_expression",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "integer_literal",
     "named": true,
     "fields": {}
@@ -1288,7 +1433,31 @@
       "required": true,
       "types": [
         {
-          "type": "_expression",
+          "type": "array_comprehension_expression",
+          "named": true
+        },
+        {
+          "type": "array_expression",
+          "named": true
+        },
+        {
+          "type": "generator_expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "matrix_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "tuple_expression",
           "named": true
         }
       ]
@@ -1420,29 +1589,6 @@
     }
   },
   {
-    "type": "macro_expression",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "argument_list",
-          "named": true
-        },
-        {
-          "type": "macro_argument_list",
-          "named": true
-        },
-        {
-          "type": "macro_identifier",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "macro_identifier",
     "named": true,
     "fields": {},
@@ -1460,6 +1606,29 @@
         },
         {
           "type": "scoped_identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "macrocall_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        },
+        {
+          "type": "macro_argument_list",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         }
       ]
@@ -1634,23 +1803,82 @@
     }
   },
   {
-    "type": "parameterized_identifier",
+    "type": "parametrized_type_expression",
     "named": true,
-    "fields": {},
+    "fields": {
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "array_comprehension_expression",
+            "named": true
+          },
+          {
+            "type": "array_expression",
+            "named": true
+          },
+          {
+            "type": "broadcast_call_expression",
+            "named": true
+          },
+          {
+            "type": "call_expression",
+            "named": true
+          },
+          {
+            "type": "field_expression",
+            "named": true
+          },
+          {
+            "type": "generator_expression",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "index_expression",
+            "named": true
+          },
+          {
+            "type": "interpolation_expression",
+            "named": true
+          },
+          {
+            "type": "matrix_expression",
+            "named": true
+          },
+          {
+            "type": "parametrized_type_expression",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "quote_expression",
+            "named": true
+          },
+          {
+            "type": "tuple_expression",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
-          "type": "field_expression",
+          "type": "_expression",
           "named": true
         },
         {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "type_argument_list",
+          "type": "subtype_clause",
           "named": true
         }
       ]
@@ -1670,14 +1898,6 @@
         },
         {
           "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "bare_tuple_expression",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
           "named": true
         }
       ]
@@ -1784,7 +2004,31 @@
       "required": true,
       "types": [
         {
-          "type": "_expression",
+          "type": "array_comprehension_expression",
+          "named": true
+        },
+        {
+          "type": "array_expression",
+          "named": true
+        },
+        {
+          "type": "generator_expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "matrix_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "tuple_expression",
           "named": true
         }
       ]
@@ -1981,7 +2225,19 @@
             "named": true
           },
           {
+            "type": "generator_expression",
+            "named": true
+          },
+          {
             "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "index_expression",
+            "named": true
+          },
+          {
+            "type": "interpolation_expression",
             "named": true
           },
           {
@@ -1989,7 +2245,7 @@
             "named": true
           },
           {
-            "type": "parameterized_identifier",
+            "type": "parametrized_type_expression",
             "named": true
           },
           {
@@ -2001,7 +2257,7 @@
             "named": true
           },
           {
-            "type": "subscript_expression",
+            "type": "quote_expression",
             "named": true
           },
           {
@@ -2184,21 +2440,6 @@
     }
   },
   {
-    "type": "subscript_expression",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "_expression",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "subtype_clause",
     "named": true,
     "fields": {},
@@ -2283,21 +2524,6 @@
     }
   },
   {
-    "type": "type_argument_list",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "_expression",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "type_parameter_list",
     "named": true,
     "fields": {},
@@ -2374,7 +2600,19 @@
             "named": true
           },
           {
+            "type": "generator_expression",
+            "named": true
+          },
+          {
             "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "index_expression",
+            "named": true
+          },
+          {
+            "type": "interpolation_expression",
             "named": true
           },
           {
@@ -2382,7 +2620,7 @@
             "named": true
           },
           {
-            "type": "parameterized_identifier",
+            "type": "parametrized_type_expression",
             "named": true
           },
           {
@@ -2394,7 +2632,7 @@
             "named": true
           },
           {
-            "type": "subscript_expression",
+            "type": "quote_expression",
             "named": true
           },
           {

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -129,7 +129,7 @@ end
     (subtype_clause (identifier))
     (typed_expression
       (identifier)
-      (parameterized_identifier (identifier) (type_argument_list (identifier))))))
+      (parametrized_type_expression (identifier) (identifier)))))
 
 
 ==============================
@@ -294,7 +294,7 @@ end
   (function_definition
     parameters: (parameter_list
                   (typed_parameter
-                    type: (parameterized_identifier (identifier) (type_argument_list (identifier))))
+                    type: (parametrized_type_expression value: (identifier) (identifier)))
                   (optional_parameter
                     (typed_parameter
                       parameter: (identifier)
@@ -343,8 +343,8 @@ end
                   (identifier)
                   (typed_parameter
                     parameter: (identifier)
-                    type: (field_expression (identifier) (identifier))))
-    return_type: (field_expression (identifier) (identifier))
+                    type: (field_expression value: (identifier) (identifier))))
+    return_type: (field_expression value: (identifier) (identifier))
     (call_expression
       (identifier)
       (argument_list

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -28,15 +28,95 @@ logŷ
   (identifier))
 
 
-=================
-Function calls
-=================
+==============================
+field expressions
+==============================
 
-a()
-b("hi", 2)
-c(d...)
-d(e; f = g)
-h(i; j)
+foo.x
+bar.x.y.z
+
+(a[1].b().c).d
+
+---
+
+(source_file
+  (field_expression
+    (identifier)
+    (identifier))
+  (field_expression
+    (field_expression
+      (field_expression
+        (identifier)
+        (identifier))
+      (identifier))
+      (identifier))
+
+  (field_expression
+    (parenthesized_expression
+      (field_expression
+        (call_expression
+          (field_expression
+            (index_expression (identifier) (integer_literal))
+            (identifier))
+          (argument_list))
+        (identifier)))
+    (identifier)))
+
+
+==============================
+index expressions
+==============================
+
+a[1, 2, 3]
+a[1, :]
+
+---
+(source_file
+  (index_expression
+    (identifier)
+    (integer_literal)
+    (integer_literal)
+    (integer_literal))
+  (index_expression
+    (identifier)
+    (integer_literal)
+    (operator)))
+
+
+==============================
+type parameterized expressions
+==============================
+
+Vector{Int}
+Vector{<:Number}
+$(usertype){T}
+
+
+---
+
+(source_file
+  (parametrized_type_expression
+    (identifier)
+    (identifier))
+  (parametrized_type_expression
+    (identifier)
+    (subtype_clause (identifier)))
+  (parametrized_type_expression
+    (interpolation_expression (parenthesized_expression (identifier)))
+    (identifier)))
+
+
+==============================
+function call expressions
+==============================
+
+f()
+g("hi", 2)
+h(d...)
+
+f(e; f = g)
+g(arg; kwarg)
+
 new{typeof(xs)}(xs)
 
 ---
@@ -45,13 +125,20 @@ new{typeof(xs)}(xs)
   (call_expression (identifier) (argument_list))
   (call_expression (identifier) (argument_list (string_literal) (integer_literal)))
   (call_expression (identifier) (argument_list (spread_expression (identifier))))
-  (call_expression (identifier) (argument_list (identifier) (named_argument (identifier) (identifier))))
-  (call_expression (identifier) (argument_list (identifier) (identifier)))
+
   (call_expression
-    (parameterized_identifier
+    (identifier)
+    (argument_list
       (identifier)
-      (type_argument_list
-        (call_expression (identifier) (argument_list (identifier)))))
+      (named_argument (identifier) (identifier))))
+  (call_expression
+    (identifier)
+    (argument_list (identifier) (identifier)))
+
+  (call_expression
+    (parametrized_type_expression
+      (identifier)
+      (call_expression (identifier) (argument_list (identifier))))
     (argument_list (identifier))))
 
 
@@ -77,56 +164,133 @@ end
         (identifier)
         (argument_list (identifier) (identifier))))))
 
-=====================
-Fields and subscripts
-=====================
 
-(a[1].b().c).d
+==============================
+macro expressions
+==============================
 
----
+@enum(Light, red, yellow, green)
 
-(source_file
-  (field_expression
-    (parenthesized_expression (field_expression
-      (call_expression
-        (field_expression
-          (subscript_expression (identifier) (integer_literal))
-          (identifier))
-        (argument_list))
-      (identifier)))
-    (identifier)))
+joinpath(@__DIR__, "grammar.js")
 
-=================
-Macro calls
-=================
-
-@assert x == y
 @assert x == y "a message"
 
-@. a
+@. a * x + b
 
 @testset "a" begin
   b = c
 end
 
+@macroexpand @async accept(socket)
+
 ---
 
 (source_file
-  (macro_expression
+  (macrocall_expression
     (macro_identifier (identifier))
-    (macro_argument_list
-      (binary_expression (identifier) (operator) (identifier))))
-  (macro_expression
+    (argument_list (identifier) (identifier) (identifier) (identifier)))
+
+  (call_expression
+    (identifier)
+    (argument_list
+      (macrocall_expression (macro_identifier (identifier)))
+      (string_literal)))
+
+  (macrocall_expression
     (macro_identifier (identifier))
     (macro_argument_list
       (binary_expression (identifier) (operator) (identifier))
       (string_literal)))
-  (macro_expression (macro_identifier (operator)) (macro_argument_list (identifier)))
-  (macro_expression
+
+  (macrocall_expression
+    (macro_identifier (operator))
+    (macro_argument_list
+      (binary_expression
+        (binary_expression (identifier) (operator) (identifier))
+        (operator)
+        (identifier))))
+
+  (macrocall_expression
     (macro_identifier (identifier))
     (macro_argument_list
       (string_literal)
-      (compound_statement (assignment_expression (identifier) (operator) (identifier))))))
+      (compound_statement (assignment_expression (identifier) (operator) (identifier)))))
+
+  (macrocall_expression
+    (macro_identifier (identifier))
+    (macro_argument_list
+      (macrocall_expression
+        (macro_identifier (identifier))
+        (macro_argument_list
+          (call_expression (identifier) (argument_list (identifier))))))))
+
+
+==============================
+quote expressions
+==============================
+
+:foo
+:const
+
+:(x; y)
+:(x, y)
+:[x, y, z]
+
+
+---
+(source_file
+  (quote_expression (identifier))
+  (quote_expression (identifier))
+
+  (quote_expression
+    (parenthesized_expression
+      (identifier)
+      (identifier)))
+  (quote_expression
+    (tuple_expression
+      (identifier)
+      (identifier)))
+  (quote_expression
+    (array_expression
+      (identifier)
+      (identifier)
+      (identifier))))
+
+
+==============================
+interpolation expressions
+==============================
+
+$foo
+$obj.field
+$(obj.field)
+$f(x)
+$f[1, 2]
+
+---
+
+(source_file
+  (interpolation_expression
+    (identifier))
+  (field_expression
+    (interpolation_expression
+      (identifier))
+    (identifier))
+  (interpolation_expression
+    (parenthesized_expression
+      (field_expression
+        (identifier)
+        (identifier))))
+  (call_expression
+    (interpolation_expression
+      (identifier))
+    (argument_list
+      (identifier)))
+  (index_expression
+    (interpolation_expression
+      (identifier))
+    (integer_literal)
+    (integer_literal)))
 
 
 ===========================


### PR DESCRIPTION
- Add `_quotable` rule for expressions that can be quoted without extra parentheses and disallow arbitrary expressions in quotes and interpolations.
- Add quote and interpolation expressions to `_primary_expression`.
- Add field names to values in field, index and parametrized types expressions.
- Replace `parameterized_identifier` with `parametrized_type_expression`:
  - Remove `type_argument_list`
  - Allow any `_primary_expression` to be parameterized
  - Allow subtype clauses (unary `<:`) in type arguments
  - Allow empty type argument list (e.g. `Tuple{}`)
- Rename `subscript_expression` to `index_expression`.
- Fix parenthesized expressions allowing arbitrary blocks.
- Fix identifiers allowing `@`.
- Add more tests for primary expressions: fields, indices, curly, quotes and interpolations.
- Remove 11 files from known failures.

---

- closes #10 
- closes #69 
- closes #49. Restricting quotables fixes the parsing problem listed in the issue. However, this doesn't improve #11,  so changing the precedence of the `colon_quote` might still be necessary.