### PR TITLE
Update prefixed strings

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -226,10 +226,7 @@ grammar({
       field('parameters', $.parameter_list),
       optional(seq(
         '::',
-        field('return_type', choice(
-          $._primary_expression,
-          $.prefixed_string_literal,
-        )),
+        field('return_type', $._primary_expression),
       )),
       optional($.where_clause),
     ),
@@ -290,7 +287,7 @@ grammar({
     typed_parameter: $ => seq(
       optional(field('parameter', $.identifier)),
       '::',
-      field('type', choice($._primary_expression, $.prefixed_string_literal)),
+      field('type', $._primary_expression)
     ),
 
     type_parameter_list: $ => seq(
@@ -306,10 +303,7 @@ grammar({
     constrained_type_parameter: $ => seq(
       field('type', $.identifier),
       '<:',
-      field('supertype', choice(
-        $._primary_expression,
-        $.prefixed_string_literal
-      )),
+      field('supertype', $._primary_expression),
     ),
 
 
@@ -504,6 +498,8 @@ grammar({
       $.index_expression,
       $.interpolation_expression,
       $.quote_expression,
+      $.prefixed_command_literal,
+      $.prefixed_string_literal,
     ),
 
     // Quotables are primary expressions that can be quoted without additional
@@ -676,7 +672,7 @@ grammar({
     typed_expression: $ => prec(PREC.decl, seq(
       $._expression,
       choice('::', '<:'),
-      choice($.identifier, $.parametrized_type_expression) // FIXME
+      choice($._primary_expression)
     )),
 
     bare_tuple_expression: $ => prec(-1, seq(
@@ -799,8 +795,9 @@ grammar({
         $.float_literal,
       ),
       choice(
-        $.parenthesized_expression,
-        $.identifier
+        $._quotable,
+        $.prefixed_command_literal,
+        $.prefixed_string_literal,
       )
     )),
 
@@ -877,8 +874,6 @@ grammar({
       $.character_literal,
       $.string_literal,
       $.command_literal,
-      $.prefixed_string_literal,
-      $.prefixed_command_literal,
     ),
 
     true: $ => 'true',
@@ -927,7 +922,7 @@ grammar({
         $.escape_sequence,
         /[^'\\]/,
       ),
-      "'",
+      token.immediate("'"),
     ),
 
     string_literal: $ => seq(
@@ -960,7 +955,7 @@ grammar({
       '$',
       choice(
         $.identifier,
-        seq('(', $._expression, ')'),
+        seq(token.immediate('('), $._expression, ')'),
       ),
     ),
 

--- a/script/known-failures.txt
+++ b/script/known-failures.txt
@@ -1,7 +1,6 @@
 examples/Flux.jl/src/losses/utils.jl
 examples/Flux.jl/src/layers/conv.jl
 examples/Flux.jl/src/layers/basic.jl
-examples/Flux.jl/src/optimise/optimisers.jl
 examples/Flux.jl/src/cuda/cudnn.jl
 examples/Flux.jl/src/cuda/curnn.jl
 examples/Flux.jl/src/zeros.jl
@@ -28,13 +27,9 @@ examples/Gadfly.jl/src/bincount.jl
 examples/Gadfly.jl/src/poetry.jl
 examples/Gadfly.jl/src/ticks.jl
 examples/Gadfly.jl/src/geom/segment.jl
-examples/Gadfly.jl/src/geom/errorbar.jl
 examples/Gadfly.jl/src/geom/hexbin.jl
 examples/Gadfly.jl/src/geom/bar.jl
-examples/Gadfly.jl/src/geom/ribbon.jl
-examples/Gadfly.jl/src/geom/polygon.jl
 examples/Gadfly.jl/src/geom/subplot.jl
-examples/Gadfly.jl/src/geom/line.jl
 examples/Gadfly.jl/src/geom/rectbin.jl
 examples/Gadfly.jl/src/geom/boxplot.jl
 examples/Gadfly.jl/src/aesthetics.jl

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -542,17 +542,8 @@
                   "type": "FIELD",
                   "name": "return_type",
                   "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_primary_expression"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "prefixed_string_literal"
-                      }
-                    ]
+                    "type": "SYMBOL",
+                    "name": "_primary_expression"
                   }
                 }
               ]
@@ -887,17 +878,8 @@
           "type": "FIELD",
           "name": "type",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_primary_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "prefixed_string_literal"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_primary_expression"
           }
         }
       ]
@@ -985,17 +967,8 @@
           "type": "FIELD",
           "name": "supertype",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_primary_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "prefixed_string_literal"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_primary_expression"
           }
         }
       ]
@@ -2043,6 +2016,14 @@
         {
           "type": "SYMBOL",
           "name": "quote_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "prefixed_command_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "prefixed_string_literal"
         }
       ]
     },
@@ -2081,7 +2062,7 @@
     },
     "field_expression": {
       "type": "PREC",
-      "value": 27,
+      "value": 28,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2262,7 +2243,7 @@
     },
     "call_expression": {
       "type": "PREC",
-      "value": 25,
+      "value": 26,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2313,7 +2294,7 @@
     },
     "broadcast_call_expression": {
       "type": "PREC",
-      "value": 25,
+      "value": 26,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2750,7 +2731,7 @@
     },
     "spread_expression": {
       "type": "PREC",
-      "value": 27,
+      "value": 28,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2827,7 +2808,7 @@
       "members": [
         {
           "type": "PREC",
-          "value": 29,
+          "value": 30,
           "content": {
             "type": "SEQ",
             "members": [
@@ -2849,7 +2830,7 @@
         },
         {
           "type": "PREC",
-          "value": 28,
+          "value": 29,
           "content": {
             "type": "SEQ",
             "members": [
@@ -2876,7 +2857,7 @@
       "members": [
         {
           "type": "PREC_LEFT",
-          "value": 24,
+          "value": 25,
           "content": {
             "type": "SEQ",
             "members": [
@@ -2902,7 +2883,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 22,
+          "value": 23,
           "content": {
             "type": "SEQ",
             "members": [
@@ -2928,7 +2909,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 23,
+          "value": 24,
           "content": {
             "type": "SEQ",
             "members": [
@@ -2954,7 +2935,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 21,
+          "value": 22,
           "content": {
             "type": "SEQ",
             "members": [
@@ -2980,7 +2961,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 20,
+          "value": 21,
           "content": {
             "type": "SEQ",
             "members": [
@@ -3015,7 +2996,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 19,
+          "value": 20,
           "content": {
             "type": "SEQ",
             "members": [
@@ -3262,7 +3243,7 @@
     },
     "typed_expression": {
       "type": "PREC",
-      "value": 26,
+      "value": 27,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3288,11 +3269,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "parametrized_type_expression"
+                "name": "_primary_expression"
               }
             ]
           }
@@ -3937,7 +3914,7 @@
     },
     "range_expression": {
       "type": "PREC_LEFT",
-      "value": 19,
+      "value": 20,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3958,7 +3935,7 @@
     },
     "coefficient_expression": {
       "type": "PREC",
-      "value": 25,
+      "value": 26,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3985,11 +3962,15 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "parenthesized_expression"
+                "name": "_quotable"
               },
               {
                 "type": "SYMBOL",
-                "name": "identifier"
+                "name": "prefixed_command_literal"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "prefixed_string_literal"
               }
             ]
           }
@@ -3998,7 +3979,7 @@
     },
     "quote_expression": {
       "type": "PREC_LEFT",
-      "value": 29,
+      "value": 19,
       "content": {
         "type": "SEQ",
         "members": [
@@ -4015,7 +3996,7 @@
     },
     "interpolation_expression": {
       "type": "PREC_LEFT",
-      "value": 29,
+      "value": 19,
       "content": {
         "type": "SEQ",
         "members": [
@@ -4165,14 +4146,6 @@
         {
           "type": "SYMBOL",
           "name": "command_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "prefixed_string_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "prefixed_command_literal"
         }
       ]
     },
@@ -4438,8 +4411,11 @@
           ]
         },
         {
-          "type": "STRING",
-          "value": "'"
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "'"
+          }
         }
       ]
     },
@@ -4601,8 +4577,11 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "STRING",
-                  "value": "("
+                  "type": "IMMEDIATE_TOKEN",
+                  "content": {
+                    "type": "STRING",
+                    "value": "("
+                  }
                 },
                 {
                   "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -452,6 +452,14 @@
           "named": true
         },
         {
+          "type": "prefixed_command_literal",
+          "named": true
+        },
+        {
+          "type": "prefixed_string_literal",
+          "named": true
+        },
+        {
           "type": "quote_expression",
           "named": true
         },
@@ -531,6 +539,14 @@
           "named": true
         },
         {
+          "type": "prefixed_command_literal",
+          "named": true
+        },
+        {
+          "type": "prefixed_string_literal",
+          "named": true
+        },
+        {
           "type": "quote_expression",
           "named": true
         },
@@ -592,7 +608,19 @@
       "required": true,
       "types": [
         {
+          "type": "array_comprehension_expression",
+          "named": true
+        },
+        {
+          "type": "array_expression",
+          "named": true
+        },
+        {
           "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "generator_expression",
           "named": true
         },
         {
@@ -604,7 +632,23 @@
           "named": true
         },
         {
+          "type": "matrix_expression",
+          "named": true
+        },
+        {
           "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "prefixed_command_literal",
+          "named": true
+        },
+        {
+          "type": "prefixed_string_literal",
+          "named": true
+        },
+        {
+          "type": "tuple_expression",
           "named": true
         }
       ]
@@ -725,6 +769,10 @@
           },
           {
             "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "prefixed_command_literal",
             "named": true
           },
           {
@@ -929,6 +977,14 @@
             "named": true
           },
           {
+            "type": "prefixed_command_literal",
+            "named": true
+          },
+          {
+            "type": "prefixed_string_literal",
+            "named": true
+          },
+          {
             "type": "quote_expression",
             "named": true
           },
@@ -1120,6 +1176,10 @@
           },
           {
             "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "prefixed_command_literal",
             "named": true
           },
           {
@@ -1395,6 +1455,14 @@
           },
           {
             "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "prefixed_command_literal",
+            "named": true
+          },
+          {
+            "type": "prefixed_string_literal",
             "named": true
           },
           {
@@ -1859,6 +1927,14 @@
             "named": true
           },
           {
+            "type": "prefixed_command_literal",
+            "named": true
+          },
+          {
+            "type": "prefixed_string_literal",
+            "named": true
+          },
+          {
             "type": "quote_expression",
             "named": true
           },
@@ -2253,6 +2329,10 @@
             "named": true
           },
           {
+            "type": "prefixed_command_literal",
+            "named": true
+          },
+          {
             "type": "prefixed_string_literal",
             "named": true
           },
@@ -2625,6 +2705,10 @@
           },
           {
             "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "prefixed_command_literal",
             "named": true
           },
           {

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -297,10 +297,9 @@ $f[1, 2]
 Coefficient expressions
 ===========================
 
-2x^2 - 3x + 1
-1.5x^2 - .5x + 1
-2^2x
+2x^2 - .3x + 1
 2(x-1)^2 - 3(x-1) + 1
+5u"kg"
 
 ---
 
@@ -312,23 +311,9 @@ Coefficient expressions
         (operator)
         (integer_literal))
       (operator)
-      (coefficient_expression (integer_literal) (identifier)))
-    (operator)
-    (integer_literal))
-  (binary_expression
-    (binary_expression
-      (binary_expression
-        (coefficient_expression (float_literal) (identifier))
-        (operator)
-        (integer_literal))
-      (operator)
       (coefficient_expression (float_literal) (identifier)))
     (operator)
     (integer_literal))
-  (binary_expression
-    (integer_literal)
-    (operator)
-    (coefficient_expression (integer_literal) (identifier)))
   (binary_expression
     (binary_expression
       (binary_expression
@@ -342,7 +327,10 @@ Coefficient expressions
         (integer_literal)
         (parenthesized_expression (binary_expression (identifier) (operator) (integer_literal)))))
     (operator)
-    (integer_literal)))
+    (integer_literal))
+  (coefficient_expression
+    (integer_literal)
+    (prefixed_string_literal (identifier))))
 
 =================
 Tuples


### PR DESCRIPTION
- Make `prefixed_string_literal` and `prefixed_command_literal` primary expressions instead of literals.
- Allow quotables and prefixed strings in coefficient expressions.
- Allow `_primary_expression` in any type position (type arguments, RHS of typed expressions, etc).
- Fix `character_literal` allowing trailing whitespace.
- Fix `string_interpolation` allowing whitespace after `$`.
- Remove 5 files from known-failures.

---

This could've gone in #72 but whatever.

closes #39 and closes #55 (duplicate)