### PR TITLE
Add function objects and update typed parameters

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -220,6 +220,7 @@ grammar({
         $.identifier,
         $.operator,
         $.scoped_identifier,
+        seq('(', alias($.typed_parameter, $.function_object), ')'),
       )),
       field('type_parameters', optional($.type_parameter_list)),
       $._immediate_paren,
@@ -237,6 +238,7 @@ grammar({
         $.identifier,
         $.type_parameter_list,
       ),
+      optional($.subtype_clause),
     ),
 
     macro_definition: $ => seq(
@@ -257,7 +259,8 @@ grammar({
         $.identifier,
         $.slurp_parameter,
         $.optional_parameter,
-        $.typed_parameter
+        $.typed_parameter,
+        $.tuple_expression,
       )),
       optional($.keyword_parameters),
       ')'
@@ -287,7 +290,8 @@ grammar({
     typed_parameter: $ => seq(
       optional(field('parameter', $.identifier)),
       '::',
-      field('type', $._primary_expression)
+      field('type', $._primary_expression),
+      optional($.where_clause),
     ),
 
     type_parameter_list: $ => seq(

--- a/script/known-failures.txt
+++ b/script/known-failures.txt
@@ -1,7 +1,4 @@
 examples/Flux.jl/src/losses/utils.jl
-examples/Flux.jl/src/layers/conv.jl
-examples/Flux.jl/src/layers/basic.jl
-examples/Flux.jl/src/cuda/cudnn.jl
 examples/Flux.jl/src/cuda/curnn.jl
 examples/Flux.jl/src/zeros.jl
 examples/Gadfly.jl/test/testscripts/timeseries_month.jl
@@ -17,14 +14,11 @@ examples/Gadfly.jl/test/runtests.jl
 examples/Gadfly.jl/test/regen-precompiles.jl
 examples/Gadfly.jl/test/compare_examples.jl
 examples/Gadfly.jl/src/statistics.jl
-examples/Gadfly.jl/src/dataframes.jl
-examples/Gadfly.jl/src/scale/scales.jl
 examples/Gadfly.jl/src/data.jl
 examples/Gadfly.jl/src/Gadfly.jl
 examples/Gadfly.jl/src/varset.jl
 examples/Gadfly.jl/src/scale.jl
 examples/Gadfly.jl/src/bincount.jl
-examples/Gadfly.jl/src/poetry.jl
 examples/Gadfly.jl/src/ticks.jl
 examples/Gadfly.jl/src/geom/segment.jl
 examples/Gadfly.jl/src/geom/hexbin.jl
@@ -134,7 +128,6 @@ examples/IJulia.jl/deps/build.jl
 examples/IJulia.jl/src/init.jl
 examples/IJulia.jl/src/stdio.jl
 examples/IJulia.jl/src/magics.jl
-examples/IJulia.jl/src/comm_manager.jl
 examples/IJulia.jl/src/execute_request.jl
 examples/IJulia.jl/src/handlers.jl
 examples/IJulia.jl/src/IJulia.jl

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -496,6 +496,28 @@
               {
                 "type": "SYMBOL",
                 "name": "scoped_identifier"
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "("
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "typed_parameter"
+                    },
+                    "named": true,
+                    "value": "function_object"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ")"
+                  }
+                ]
               }
             ]
           }
@@ -586,6 +608,18 @@
               "name": "type_parameter_list"
             }
           ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "subtype_clause"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -674,6 +708,10 @@
                     {
                       "type": "SYMBOL",
                       "name": "typed_parameter"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "tuple_expression"
                     }
                   ]
                 },
@@ -704,6 +742,10 @@
                           {
                             "type": "SYMBOL",
                             "name": "typed_parameter"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "tuple_expression"
                           }
                         ]
                       }
@@ -881,6 +923,18 @@
             "type": "SYMBOL",
             "name": "_primary_expression"
           }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "where_clause"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1099,9 +1099,21 @@
     "named": true,
     "fields": {
       "name": {
-        "multiple": false,
+        "multiple": true,
         "required": false,
         "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "function_object",
+            "named": true
+          },
           {
             "type": "identifier",
             "named": true
@@ -1252,6 +1264,102 @@
         },
         {
           "type": "parameter_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "function_object",
+    "named": true,
+    "fields": {
+      "parameter": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "array_comprehension_expression",
+            "named": true
+          },
+          {
+            "type": "array_expression",
+            "named": true
+          },
+          {
+            "type": "broadcast_call_expression",
+            "named": true
+          },
+          {
+            "type": "call_expression",
+            "named": true
+          },
+          {
+            "type": "field_expression",
+            "named": true
+          },
+          {
+            "type": "generator_expression",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "index_expression",
+            "named": true
+          },
+          {
+            "type": "interpolation_expression",
+            "named": true
+          },
+          {
+            "type": "matrix_expression",
+            "named": true
+          },
+          {
+            "type": "parametrized_type_expression",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "prefixed_command_literal",
+            "named": true
+          },
+          {
+            "type": "prefixed_string_literal",
+            "named": true
+          },
+          {
+            "type": "quote_expression",
+            "named": true
+          },
+          {
+            "type": "tuple_expression",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "where_clause",
           "named": true
         }
       ]
@@ -1864,6 +1972,10 @@
           "named": true
         },
         {
+          "type": "tuple_expression",
+          "named": true
+        },
+        {
           "type": "typed_parameter",
           "named": true
         }
@@ -2249,9 +2361,21 @@
     "named": true,
     "fields": {
       "name": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "function_object",
+            "named": true
+          },
           {
             "type": "identifier",
             "named": true
@@ -2725,6 +2849,16 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "where_clause",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -2762,11 +2896,15 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "subtype_clause",
           "named": true
         },
         {

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -160,6 +160,9 @@ function fix2(f, x)
     end
 end
 
+function (foo::Foo)()
+end
+
 ---
 
 (source_file
@@ -205,7 +208,14 @@ end
         parameters: (parameter_list (identifier))
         (call_expression
           (identifier)
-          (argument_list (identifier) (identifier)))))))
+          (argument_list (identifier) (identifier))))))
+
+  ;; Function Objects
+  (function_definition
+    name: (function_object
+            parameter: (identifier)
+            type: (identifier))
+    parameters: (parameter_list)))
 
 
 ==============================
@@ -273,6 +283,10 @@ end
 
 function bar(f, xs::Foo.Bar)::Foo.Bar
     map(f, xs)
+end
+
+function swap((x, y))
+    (y, x)
 end
 
 
@@ -349,7 +363,14 @@ end
       (identifier)
       (argument_list
         (identifier)
-        (identifier)))))
+        (identifier))))
+
+  ;; Tuple parameters
+  (function_definition
+    name: (identifier)
+    parameters: (parameter_list (tuple_expression (identifier) (identifier)))
+    (tuple_expression (identifier) (identifier))))
+
 
 
 ==================================================
@@ -366,6 +387,10 @@ end
 f(n::N) where {N <: Integer} = n
 
 Foo{T}(x::T) where {T} = x
+
+function norm(p::Point{T} where T<:Real)
+    norm2(p)
+end
 
 Base.show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m, kwargs)
 
@@ -421,6 +446,21 @@ Base.show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m,
     (where_clause
       (type_parameter_list (identifier)))
     (identifier))
+
+  ;; `where` clauses in parameters
+  (function_definition
+    name: (identifier)
+    parameters: (parameter_list
+                  (typed_parameter
+                    parameter: (identifier)
+                    type: (parametrized_type_expression
+                            value: (identifier)
+                            (identifier))
+                    (where_clause
+                      (identifier)
+                      (subtype_clause
+                        (identifier)))))
+    (call_expression (identifier) (argument_list (identifier))))
 
   ;; Almost everything at once
   (short_function_definition


### PR DESCRIPTION
- Add function object syntax
- Allow `where_clause` in `typed_parameter`
- Allow `subtype_clause` in `where_clause`
- Allow tuples as parameters

---
- Closes #20 
- Closes #70 