### PR TITLE
Update declarations and assignments

### DIFF
--- a/script/known-failures.txt
+++ b/script/known-failures.txt
@@ -10,7 +10,6 @@ examples/Gadfly.jl/test/testscripts/timeseries_year_3.jl
 examples/Gadfly.jl/test/testscripts/unitful_geoms.jl
 examples/Gadfly.jl/test/testscripts/timeseries_year_1.jl
 examples/Gadfly.jl/test/testscripts/unitful_color.jl
-examples/Gadfly.jl/test/runtests.jl
 examples/Gadfly.jl/test/regen-precompiles.jl
 examples/Gadfly.jl/test/compare_examples.jl
 examples/Gadfly.jl/src/statistics.jl
@@ -27,7 +26,6 @@ examples/Gadfly.jl/src/geom/subplot.jl
 examples/Gadfly.jl/src/geom/rectbin.jl
 examples/Gadfly.jl/src/geom/boxplot.jl
 examples/Gadfly.jl/src/aesthetics.jl
-examples/Gadfly.jl/src/misc.jl
 examples/Gadfly.jl/src/color_misc.jl
 examples/Gadfly.jl/src/guide.jl
 examples/Mocha.jl/tools/image-classifier.jl
@@ -49,7 +47,6 @@ examples/Mocha.jl/test/layers/concat.jl
 examples/Mocha.jl/test/layers/convolution.jl
 examples/Mocha.jl/test/utils/ref-count.jl
 examples/Mocha.jl/examples/mnist/mnist-demo.jl
-examples/Mocha.jl/examples/cifar10/convert.jl
 examples/Mocha.jl/benchmarks/parallel-loop/parallel-pool-module.jl
 examples/Mocha.jl/src/parameter.jl
 examples/Mocha.jl/src/constraints.jl
@@ -130,4 +127,3 @@ examples/IJulia.jl/src/stdio.jl
 examples/IJulia.jl/src/magics.jl
 examples/IJulia.jl/src/execute_request.jl
 examples/IJulia.jl/src/handlers.jl
-examples/IJulia.jl/src/IJulia.jl

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -29,15 +29,19 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "assignment_expression"
+                  "name": "_declaration"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "assignment"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "bare_tuple"
                 },
                 {
                   "type": "SYMBOL",
                   "name": "short_function_definition"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "bare_tuple_expression"
                 }
               ]
             },
@@ -59,15 +63,19 @@
                       },
                       {
                         "type": "SYMBOL",
-                        "name": "assignment_expression"
+                        "name": "_declaration"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "assignment"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "bare_tuple"
                       },
                       {
                         "type": "SYMBOL",
                         "name": "short_function_definition"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "bare_tuple_expression"
                       }
                     ]
                   }
@@ -1072,10 +1080,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "const_statement"
-        },
-        {
-          "type": "SYMBOL",
           "name": "export_statement"
         },
         {
@@ -1149,7 +1153,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "variable_declaration"
+                  "name": "let_binding"
                 },
                 {
                   "type": "REPEAT",
@@ -1162,7 +1166,7 @@
                       },
                       {
                         "type": "SYMBOL",
-                        "name": "variable_declaration"
+                        "name": "let_binding"
                       }
                     ]
                   }
@@ -1195,6 +1199,40 @@
           "value": "end"
         }
       ]
+    },
+    "let_binding": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "="
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "if_statement": {
       "type": "SEQ",
@@ -1598,79 +1636,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "bare_tuple_expression"
-                  }
-                ]
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "const_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "const"
-        },
-        {
-          "type": "PREC_RIGHT",
-          "value": 0,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "variable_declaration"
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ","
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "variable_declaration"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      ]
-    },
-    "variable_declaration": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "identifier"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "="
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_expression"
+                    "name": "bare_tuple"
                   }
                 ]
               },
@@ -2005,6 +1971,10 @@
         {
           "type": "SYMBOL",
           "name": "macrocall_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "compound_assignment_expression"
         },
         {
           "type": "SYMBOL",
@@ -2447,8 +2417,21 @@
           "type": "PREC",
           "value": -1,
           "content": {
-            "type": "SYMBOL",
-            "name": "_expression"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "named_field"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "short_function_definition"
+              }
+            ]
           }
         }
       }
@@ -2800,59 +2783,28 @@
         ]
       }
     },
-    "assignment_expression": {
+    "compound_assignment_expression": {
       "type": "PREC_RIGHT",
       "value": 10,
       "content": {
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "bare_tuple_expression"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_primary_expression"
           },
           {
             "type": "ALIAS",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_assign_operator"
-                },
-                {
-                  "type": "STRING",
-                  "value": "="
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_assign_operator"
             },
             "named": true,
             "value": "operator"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "assignment_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "bare_tuple_expression"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_expression"
           }
         ]
       }
@@ -3330,39 +3282,6 @@
         ]
       }
     },
-    "bare_tuple_expression": {
-      "type": "PREC",
-      "value": -1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_expression"
-          },
-          {
-            "type": "REPEAT1",
-            "content": {
-              "type": "PREC",
-              "value": -1,
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_expression"
-                  }
-                ]
-              }
-            }
-          }
-        ]
-      }
-    },
     "tuple_expression": {
       "type": "SEQ",
       "members": [
@@ -3576,7 +3495,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "assignment_expression"
+                  "name": "assignment"
                 }
               ]
             },
@@ -3598,7 +3517,7 @@
                       },
                       {
                         "type": "SYMBOL",
-                        "name": "assignment_expression"
+                        "name": "assignment"
                       }
                     ]
                   }
@@ -3639,17 +3558,8 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_expression"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "assignment_expression"
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "_expression"
                 },
                 {
                   "type": "REPEAT",
@@ -3661,17 +3571,8 @@
                         "value": ","
                       },
                       {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "_expression"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "assignment_expression"
-                          }
-                        ]
+                        "type": "SYMBOL",
+                        "name": "_expression"
                       }
                     ]
                   }
@@ -3959,7 +3860,11 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "assignment_expression"
+                "name": "assignment"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "bare_tuple"
               }
             ]
           }
@@ -4042,8 +3947,35 @@
             "value": ":"
           },
           {
-            "type": "SYMBOL",
-            "name": "_quotable"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_quotable"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "global"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "local"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "end"
+                    }
+                  ]
+                },
+                "named": true,
+                "value": "identifier"
+              }
+            ]
           }
         ]
       }
@@ -4061,6 +3993,240 @@
           {
             "type": "SYMBOL",
             "name": "_quotable"
+          }
+        ]
+      }
+    },
+    "assignment": {
+      "type": "PREC_RIGHT",
+      "value": 10,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_quotable"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "field_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "index_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "interpolation_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "typed_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "operator"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "prefixed_command_literal"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "prefixed_string_literal"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "binary_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "unary_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "bare_tuple"
+              }
+            ]
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "."
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "="
+                    }
+                  ]
+                }
+              ]
+            },
+            "named": true,
+            "value": "operator"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "assignment"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "bare_tuple"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "const_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "local_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "global_declaration"
+        }
+      ]
+    },
+    "const_declaration": {
+      "type": "PREC_RIGHT",
+      "value": -2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "const"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "assignment"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "global_declaration": {
+      "type": "PREC_RIGHT",
+      "value": -2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "global"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "assignment"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "local_declaration": {
+      "type": "PREC_RIGHT",
+      "value": -2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "local"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "assignment"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "bare_tuple": {
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "PREC",
+              "value": -1,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                ]
+              }
+            }
           }
         ]
       }
@@ -7513,23 +7679,7 @@
     ],
     [
       "_quotable",
-      "parameter_list"
-    ],
-    [
-      "_quotable",
-      "slurp_parameter"
-    ],
-    [
-      "_quotable",
-      "typed_parameter"
-    ],
-    [
-      "parameter_list",
-      "argument_list"
-    ],
-    [
-      "keyword_parameters",
-      "argument_list"
+      "scoped_identifier"
     ],
     [
       "_quotable",
@@ -7545,12 +7695,32 @@
       "named_field"
     ],
     [
-      "keyword_parameters",
-      "_implicit_named_field"
+      "_quotable",
+      "parameter_list"
     ],
     [
       "_quotable",
-      "scoped_identifier"
+      "typed_parameter"
+    ],
+    [
+      "_quotable",
+      "slurp_parameter"
+    ],
+    [
+      "parameter_list",
+      "argument_list"
+    ],
+    [
+      "keyword_parameters",
+      "tuple_expression"
+    ],
+    [
+      "keyword_parameters",
+      "argument_list"
+    ],
+    [
+      "keyword_parameters",
+      "_implicit_named_field"
     ]
   ],
   "precedences": [],
@@ -7602,9 +7772,10 @@
     "_statement"
   ],
   "supertypes": [
+    "_declaration",
+    "_definition",
     "_expression",
-    "_statement",
-    "_definition"
+    "_statement"
   ]
 }
 

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1,5 +1,23 @@
 [
   {
+    "type": "_declaration",
+    "named": true,
+    "subtypes": [
+      {
+        "type": "const_declaration",
+        "named": true
+      },
+      {
+        "type": "global_declaration",
+        "named": true
+      },
+      {
+        "type": "local_declaration",
+        "named": true
+      }
+    ]
+  },
+  {
     "type": "_definition",
     "named": true,
     "subtypes": [
@@ -71,6 +89,10 @@
       },
       {
         "type": "command_literal",
+        "named": true
+      },
+      {
+        "type": "compound_assignment_expression",
         "named": true
       },
       {
@@ -189,10 +211,6 @@
       },
       {
         "type": "compound_statement",
-        "named": true
-      },
-      {
-        "type": "const_statement",
         "named": true
       },
       {
@@ -326,16 +344,12 @@
         {
           "type": "_expression",
           "named": true
-        },
-        {
-          "type": "assignment_expression",
-          "named": true
         }
       ]
     }
   },
   {
-    "type": "assignment_expression",
+    "type": "assignment",
     "named": true,
     "fields": {},
     "children": {
@@ -347,18 +361,18 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         }
       ]
     }
   },
   {
-    "type": "bare_tuple_expression",
+    "type": "bare_tuple",
     "named": true,
     "fields": {},
     "children": {
@@ -566,15 +580,19 @@
       "required": false,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -674,6 +692,21 @@
     }
   },
   {
+    "type": "compound_assignment_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "compound_statement",
     "named": true,
     "fields": {},
@@ -682,15 +715,19 @@
       "required": false,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -701,15 +738,19 @@
     }
   },
   {
-    "type": "const_statement",
+    "type": "const_declaration",
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
         {
-          "type": "variable_declaration",
+          "type": "assignment",
+          "named": true
+        },
+        {
+          "type": "identifier",
           "named": true
         }
       ]
@@ -810,15 +851,19 @@
       "required": true,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -841,15 +886,19 @@
       "required": false,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -879,15 +928,19 @@
       "required": false,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -1015,15 +1068,19 @@
       "required": false,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -1072,15 +1129,19 @@
       "required": true,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -1224,15 +1285,19 @@
       "required": false,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -1259,7 +1324,11 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
+          "named": true
+        },
+        {
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -1389,6 +1458,25 @@
     }
   },
   {
+    "type": "global_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "assignment",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "if_clause",
     "named": true,
     "fields": {},
@@ -1437,15 +1525,19 @@
       "required": false,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -1667,6 +1759,21 @@
     }
   },
   {
+    "type": "let_binding",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "let_statement",
     "named": true,
     "fields": {},
@@ -1675,23 +1782,46 @@
       "required": false,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
+          "named": true
+        },
+        {
+          "type": "let_binding",
           "named": true
         },
         {
           "type": "short_function_definition",
           "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "local_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "assignment",
+          "named": true
         },
         {
-          "type": "variable_declaration",
+          "type": "identifier",
           "named": true
         }
       ]
@@ -1707,6 +1837,14 @@
       "types": [
         {
           "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "named_field",
+          "named": true
+        },
+        {
+          "type": "short_function_definition",
           "named": true
         }
       ]
@@ -1746,15 +1884,19 @@
       "required": false,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -1860,15 +2002,19 @@
       "required": false,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -2085,7 +2231,7 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         }
       ]
@@ -2231,15 +2377,19 @@
       "required": false,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -2296,7 +2446,7 @@
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         }
       ]
@@ -2524,15 +2674,19 @@
       "required": false,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -2621,15 +2775,19 @@
       "required": false,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -2682,15 +2840,19 @@
       "required": false,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -2877,21 +3039,6 @@
     }
   },
   {
-    "type": "variable_declaration",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "_expression",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "where_clause",
     "named": true,
     "fields": {},
@@ -2934,15 +3081,19 @@
       "required": false,
       "types": [
         {
+          "type": "_declaration",
+          "named": true
+        },
+        {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "assignment_expression",
+          "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple_expression",
+          "type": "bare_tuple",
           "named": true
         },
         {
@@ -3109,6 +3260,10 @@
     "named": false
   },
   {
+    "type": "global",
+    "named": false
+  },
+  {
     "type": "identifier",
     "named": true
   },
@@ -3131,6 +3286,10 @@
   {
     "type": "line_comment",
     "named": true
+  },
+  {
+    "type": "local",
+    "named": false
   },
   {
     "type": "macro",

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -214,7 +214,7 @@ end
     (macro_identifier (identifier))
     (macro_argument_list
       (string_literal)
-      (compound_statement (assignment_expression (identifier) (operator) (identifier)))))
+      (compound_statement (assignment (identifier) (operator) (identifier)))))
 
   (macrocall_expression
     (macro_identifier (identifier))
@@ -366,7 +366,7 @@ Named tuples
 
 (source_file
   (parenthesized_expression
-    (assignment_expression (identifier) (operator) (integer_literal)))
+    (assignment (identifier) (operator) (integer_literal)))
   (tuple_expression
     (named_field (identifier) (integer_literal)))
   (tuple_expression
@@ -449,7 +449,7 @@ x -> x^2
     (parameter_list)
     (parenthesized_expression
       (call_expression (identifier) (argument_list (float_literal)))
-      (assignment_expression (identifier) (operator) (integer_literal))
+      (compound_assignment_expression (identifier) (operator) (integer_literal))
       (identifier))))
 
 ============================

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -105,7 +105,7 @@ band = "Interpol"
   (string_literal)
   (string_literal (escape_sequence) (escape_sequence))
   (string_literal)
-  (assignment_expression
+  (assignment
     (identifier)
     (operator)
     (string_literal))
@@ -155,12 +155,12 @@ version = v"1.0"
 ---
 
 (source_file
-  (assignment_expression
+  (assignment
     (identifier)
     (operator)
     (prefixed_string_literal 
         prefix: (identifier)))
-  (assignment_expression
+  (assignment
     (identifier)
     (operator)
     (prefixed_string_literal 
@@ -188,7 +188,7 @@ nested #= comments =# =#
   (line_comment)
   (block_comment)
   (block_comment)
-  (assignment_expression (identifier) (operator) (block_comment) (integer_literal))
+  (assignment (identifier) (operator) (block_comment) (integer_literal))
   (block_comment)
   (block_comment))
 

--- a/test/corpus/operators.txt
+++ b/test/corpus/operators.txt
@@ -4,45 +4,44 @@ assignment operators
 
 a = b
 a .. b = a * b
-c &= d ÷= e
 tup = 1, 2, 3
 car, cdr... = list
+c &= d ÷= e
 
 ---
 (source_file
-  (assignment_expression
+  (assignment
     (identifier)
     (operator)
     (identifier))
 
-  (assignment_expression
+  (assignment
     (binary_expression (identifier) (operator) (identifier))
     (operator)
     (binary_expression (identifier) (operator) (identifier)))
 
-  (assignment_expression
+  (assignment
     (identifier)
     (operator)
-    (assignment_expression
-      (identifier)
-      (operator)
-      (identifier)))
-
-  (assignment_expression
-    (identifier)
-    (operator)
-    (bare_tuple_expression
+    (bare_tuple
       (integer_literal)
       (integer_literal)
       (integer_literal)))
 
-  (assignment_expression
-    (bare_tuple_expression
+  (assignment
+    (bare_tuple
       (identifier)
       (spread_expression (identifier)))
     (operator)
-    (identifier)))
+    (identifier))
 
+  (compound_assignment_expression
+    (identifier)
+    (operator)
+    (compound_assignment_expression
+      (identifier)
+      (operator)
+      (identifier))))
 
 ==============================
 binary operators
@@ -98,7 +97,7 @@ a & b | c
     (identifier))
 
   ; LA
-  (assignment_expression
+  (assignment
     (identifier)
     (operator)
     (binary_expression
@@ -227,7 +226,7 @@ x = batch_size == 1 ?
 ---
 
 (source_file
-  (assignment_expression
+  (assignment
     (identifier)
     (operator)
     (ternary_expression
@@ -247,11 +246,11 @@ foo(^, ÷, -)
 
 ---
 (source_file
-  (assignment_expression
+  (assignment
     (identifier)
     (operator)
     (operator))
-  (assignment_expression
+  (assignment
     (operator)
     (operator)
     (operator))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -38,8 +38,8 @@ end
 (source_file
   (quote_statement)
   (quote_statement
-    (assignment_expression (identifier) (operator) (integer_literal))
-    (assignment_expression (identifier) (operator) (integer_literal))
+    (assignment (identifier) (operator) (integer_literal))
+    (assignment (identifier) (operator) (integer_literal))
     (binary_expression (identifier) (operator) (identifier))))
 
 
@@ -59,9 +59,9 @@ end
 (source_file
   (let_statement)
   (let_statement
-    (variable_declaration (identifier) (identifier))
-    (variable_declaration (identifier))
-    (variable_declaration (identifier) (identifier))
+    (let_binding (identifier) (identifier))
+    (let_binding (identifier))
+    (let_binding (identifier) (identifier))
     (identifier)))
 
 
@@ -242,21 +242,7 @@ return a, b, c
   (return_statement)
   (return_statement (identifier))
   (return_statement (binary_expression (identifier) (operator) (identifier)))
-  (return_statement (bare_tuple_expression (identifier) (identifier) (identifier))))
-
-
-===============================
-Const statements
-===============================
-
-const x, y = 5
-
----
-
-(source_file
-  (const_statement
-    (variable_declaration (identifier))
-    (variable_declaration (identifier) (integer_literal))))
+  (return_statement (bare_tuple (identifier) (identifier) (identifier))))
 
 
 ==============================
@@ -319,3 +305,57 @@ import LinearAlgebra as la
   ;; Alias
   (import_statement (import_alias (identifier) (identifier))))
 
+
+===============================
+const declarations
+===============================
+
+const x = 5
+const y, z = 1, 2
+
+---
+
+(source_file
+  (const_declaration
+    (assignment (identifier) (operator) (integer_literal)))
+  (const_declaration
+    (assignment
+    (bare_tuple (identifier) (identifier))
+    (operator)
+    (bare_tuple (integer_literal) (integer_literal)))))
+
+
+===============================
+local declarations
+===============================
+
+local x
+local y, z = 1, 2
+
+---
+
+(source_file
+  (local_declaration (identifier))
+  (local_declaration
+    (assignment
+    (bare_tuple (identifier) (identifier))
+    (operator)
+    (bare_tuple (integer_literal) (integer_literal)))))
+
+
+===============================
+global declarations
+===============================
+
+global X
+global Y, Z = 11, 42
+
+---
+
+(source_file
+  (global_declaration (identifier))
+  (global_declaration
+    (assignment
+    (bare_tuple (identifier) (identifier))
+    (operator)
+    (bare_tuple (integer_literal) (integer_literal)))))


### PR DESCRIPTION
- Add local and global declarations.
- Split `assignment_expression` into `assignment` and `compound_assignment_expression` rules.
- Fix `assignment` allowing arbitrary expressions in the LHS.
- Rename `bare_tuple_expression` to `bare_tuple`.
- Add a separate rule for let bindings (these don't allow bare tuples).
- Update tests

---
Following Max's advise in https://github.com/tree-sitter/tree-sitter-julia/pull/6#issuecomment-663905837, I added an exception to parse `:local` as a quote expression. Note that currrently this is only a problem in an expression like
```
if x == :local
end
```

because this will be parsed as:
```
(if (== x :) (local end))
```


- Closes #11 
- Closes #67 


