### PR TITLE
Fix newline separated matrix expressions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -730,8 +730,10 @@ grammar({
 
     matrix_expression: $ => prec(-1, seq(
       '[',
-      sep(';', $.matrix_row),
+      optional('\n'),
+      sep(choice(';', '\n'), $.matrix_row),
       optional(';'),
+      optional('\n'),
       ']'
     )),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3715,6 +3715,18 @@
             "type": "CHOICE",
             "members": [
               {
+                "type": "STRING",
+                "value": "\n"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
                 "type": "SEQ",
                 "members": [
                   {
@@ -3727,8 +3739,17 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "STRING",
-                          "value": ";"
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": ";"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "\n"
+                            }
+                          ]
                         },
                         {
                           "type": "SYMBOL",
@@ -3750,6 +3771,18 @@
               {
                 "type": "STRING",
                 "value": ";"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\n"
               },
               {
                 "type": "BLANK"

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -404,11 +404,23 @@ Matrices
 [1 2]
 [1 2; 3 4]
 [1 2; 3 4;]
+[1 2
+3 4]
+[
+    1 2
+    3 4
+]
 
 ---
 
 (source_file
   (matrix_expression
+    (matrix_row (integer_literal) (integer_literal)))
+  (matrix_expression
+    (matrix_row (integer_literal) (integer_literal))
+    (matrix_row (integer_literal) (integer_literal)))
+  (matrix_expression
+    (matrix_row (integer_literal) (integer_literal))
     (matrix_row (integer_literal) (integer_literal)))
   (matrix_expression
     (matrix_row (integer_literal) (integer_literal))


### PR DESCRIPTION
My attempt at fixing #80. 

I've never looked into tree-sitter parsers before, so I'm sure there's a better way of doing this, but it seems to work.