### PR TITLE
Update type operators, quotations and other minor fixes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -336,6 +336,7 @@ module.exports = grammar({
         $.optional_parameter,
         $.typed_parameter,
         $.interpolation_expression,
+        alias($._closed_macrocall_expression, $.macrocall_expression),
       )),
       optional(','),
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -896,9 +896,15 @@ module.exports = grammar({
     ternary_expression: $ => prec.right(PREC.conditional, seq(
       $._expression,
       '?',
-      $._expression,
+      choice(
+        $._expression,
+        $.assignment,
+      ),
       ':',
-      $._expression
+      choice(
+        $._expression,
+        $.assignment,
+      ),
     )),
 
     typed_expression: $ => prec(PREC.decl, seq(

--- a/grammar.js
+++ b/grammar.js
@@ -206,7 +206,7 @@ module.exports = grammar({
       'type',
       field('name', choice($.identifier, $.interpolation_expression)),
       optional(seq($._immediate_brace, alias($.curly_expression, $.type_parameter_list))),
-      optional($.subtype_clause),
+      optional($.type_clause),
       'end'
     ),
 
@@ -215,7 +215,7 @@ module.exports = grammar({
       'type',
       field('name', choice($.identifier, $.interpolation_expression)),
       optional(seq($._immediate_brace, alias($.curly_expression, $.type_parameter_list))),
-      optional($.subtype_clause),
+      optional($.type_clause),
       $.integer_literal,
       'end'
     ),
@@ -225,13 +225,16 @@ module.exports = grammar({
       'struct',
       field('name', choice($.identifier, $.interpolation_expression)),
       optional(seq($._immediate_brace, alias($.curly_expression, $.type_parameter_list))),
-      optional($.subtype_clause),
+      optional($.type_clause),
       optional($._terminator),
       optional($._block),
       'end'
     ),
 
-    subtype_clause: $ => seq('<:', $._expression),
+    type_clause: $ => seq(
+      choice('<:', '>:'),
+      $._primary_expression
+    ),
 
     function_definition: $ => seq(
       'function',
@@ -292,7 +295,7 @@ module.exports = grammar({
     where_clause: $ => seq(
       'where',
       $._primary_expression,
-      optional($.subtype_clause),
+      optional($.type_clause),
     ),
 
     macro_definition: $ => seq(
@@ -643,7 +646,7 @@ module.exports = grammar({
       '{',
       sep(',', choice(
         $._expression,
-        $.subtype_clause,
+        $.type_clause,
         alias($.named_field, $.assignment),
       )),
       optional(','),
@@ -898,7 +901,7 @@ module.exports = grammar({
 
     typed_expression: $ => prec(PREC.decl, seq(
       $._expression,
-      choice('::', '<:'),
+      '::',
       choice($._primary_expression)
     )),
 

--- a/grammar.js
+++ b/grammar.js
@@ -2,9 +2,9 @@ const PREC = [
   'assign',
   'pair',
   'conditional',
+  'arrow',
   'lazy_or',
   'lazy_and',
-  'arrow',
   'comparison',
   'pipe_left',
   'pipe_right',
@@ -13,12 +13,13 @@ const PREC = [
   'times',
   'rational',
   'bitshift',
-  'power',
-  'call',
-  'decl',
-  'dot',
-  'postfix',
+  'where',
   'prefix',
+  'postfix',
+  'power',
+  'decl',
+  'call',
+  'dot',
 ].reduce((result, name, index) => {
   result[name] = index + 10;
   return result;
@@ -844,6 +845,7 @@ module.exports = grammar({
       $.function_expression,
       $.juxtaposition_expression,
       $.compound_assignment_expression,
+      $.where_expression,
       $.operator,
       alias(':', $.operator),
       prec(-1, alias('begin', $.identifier)),
@@ -918,14 +920,14 @@ module.exports = grammar({
       )
     )),
 
-    juxtaposition_expression: $ => seq(
+    juxtaposition_expression: $ => prec.left(seq(
       choice(
         $.integer_literal,
         $.float_literal,
         $.adjoint_expression,
       ),
       $._primary_expression,
-    ),
+    )),
 
     compound_assignment_expression: $ => prec.right(PREC.assign, seq(
       $._primary_expression,
@@ -933,6 +935,11 @@ module.exports = grammar({
       $._expression,
     )),
 
+    where_expression: $ => prec.left(PREC.where, seq(
+      $._expression,
+      'where',
+      $._expression,
+    )),
 
     // Assignments and declarations
 
@@ -1195,14 +1202,13 @@ module.exports = grammar({
 
     _ellipsis_operator: $ => token(choice('..', addDots(ELLIPSIS_OPERATORS))),
 
-    _pipe_right_operator: $ => token(addDots('<|')),
+    _pipe_left_operator: $ => token(addDots('<|')),
 
-    _pipe_left_operator: $ => token(addDots('|>')),
+    _pipe_right_operator: $ => token(addDots('|>')),
 
     _comparison_operator: $ => token(choice('<:', '>:', addDots(COMPARISON_OPERATORS))),
 
     _arrow_operator: $ => token(choice('<--', '-->', '<-->', addDots(ARROW_OPERATORS))),
-
 
     _pair_operator: $ => token(addDots('=>')),
 

--- a/script/known-failures.txt
+++ b/script/known-failures.txt
@@ -1,5 +1,4 @@
 examples/Flux.jl/test/utils.jl
-examples/Flux.jl/src/layers/normalise.jl
 examples/Gadfly.jl/test/testscripts/unitful_basic.jl
 examples/Gadfly.jl/test/testscripts/unitful_geoms.jl
 examples/Gadfly.jl/test/testscripts/unitful_color.jl
@@ -8,11 +7,7 @@ examples/Pluto.jl/sample/test_pkg_bubble.jl
 examples/Pluto.jl/sample/test1.jl
 examples/Pluto.jl/sample/test_go_to_definition.jl
 examples/Pluto.jl/src/analysis/FunctionDependencies.jl
-examples/Pluto.jl/src/analysis/Parse.jl
 examples/Pluto.jl/src/analysis/ExpressionExplorer.jl
 examples/Pluto.jl/src/analysis/is_just_text.jl
-examples/Pluto.jl/src/analysis/MoreAnalysis.jl
 examples/Pluto.jl/src/runner/PlutoRunner.jl
-examples/Pluto.jl/src/webserver/Static.jl
-examples/Pluto.jl/src/evaluation/MacroAnalysis.jl
 examples/IJulia.jl/src/init.jl

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -194,12 +194,24 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
-          "value": "abstract"
-        },
-        {
-          "type": "STRING",
-          "value": "type"
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "abstract"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\\s+"
+              },
+              {
+                "type": "STRING",
+                "value": "type"
+              }
+            ]
+          }
         },
         {
           "type": "FIELD",
@@ -249,7 +261,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "subtype_clause"
+              "name": "type_clause"
             },
             {
               "type": "BLANK"
@@ -266,12 +278,24 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
-          "value": "primitive"
-        },
-        {
-          "type": "STRING",
-          "value": "type"
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "primitive"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\\s+"
+              },
+              {
+                "type": "STRING",
+                "value": "type"
+              }
+            ]
+          }
         },
         {
           "type": "FIELD",
@@ -321,7 +345,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "subtype_clause"
+              "name": "type_clause"
             },
             {
               "type": "BLANK"
@@ -405,7 +429,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "subtype_clause"
+              "name": "type_clause"
             },
             {
               "type": "BLANK"
@@ -442,16 +466,25 @@
         }
       ]
     },
-    "subtype_clause": {
+    "type_clause": {
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
-          "value": "<:"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "<:"
+            },
+            {
+              "type": "STRING",
+              "value": ">:"
+            }
+          ]
         },
         {
           "type": "SYMBOL",
-          "name": "_expression"
+          "name": "_primary_expression"
         }
       ]
     },
@@ -746,7 +779,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "subtype_clause"
+              "name": "type_clause"
             },
             {
               "type": "BLANK"
@@ -1003,6 +1036,15 @@
                 {
                   "type": "SYMBOL",
                   "name": "interpolation_expression"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_closed_macrocall_expression"
+                  },
+                  "named": true,
+                  "value": "macrocall_expression"
                 }
               ]
             },
@@ -1037,6 +1079,15 @@
                       {
                         "type": "SYMBOL",
                         "name": "interpolation_expression"
+                      },
+                      {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_closed_macrocall_expression"
+                        },
+                        "named": true,
+                        "value": "macrocall_expression"
                       }
                     ]
                   }
@@ -2223,10 +2274,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "generator_expression"
-        },
-        {
-          "type": "SYMBOL",
           "name": "parenthesized_expression"
         },
         {
@@ -2387,38 +2434,42 @@
       ]
     },
     "for_clause": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "for"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "for_binding"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "for_binding"
-                  }
-                ]
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "for"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "for_binding"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "for_binding"
+                    }
+                  ]
+                }
               }
-            }
-          ]
-        }
-      ]
+            ]
+          }
+        ]
+      }
     },
     "for_binding": {
       "type": "SEQ",
@@ -2782,6 +2833,18 @@
           "type": "CHOICE",
           "members": [
             {
+              "type": "SYMBOL",
+              "name": "_comprehension_clause"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
               "type": "STRING",
               "value": ";"
             },
@@ -2876,8 +2939,17 @@
                       "type": "CHOICE",
                       "members": [
                         {
-                          "type": "STRING",
-                          "value": ","
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "_comprehension_clause"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": ","
+                            }
+                          ]
                         },
                         {
                           "type": "BLANK"
@@ -2989,7 +3061,7 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "subtype_clause"
+                      "name": "type_clause"
                     },
                     {
                       "type": "ALIAS",
@@ -3020,7 +3092,7 @@
                           },
                           {
                             "type": "SYMBOL",
-                            "name": "subtype_clause"
+                            "name": "type_clause"
                           },
                           {
                             "type": "ALIAS",
@@ -3117,7 +3189,7 @@
     },
     "field_expression": {
       "type": "PREC",
-      "value": 27,
+      "value": 30,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3221,7 +3293,7 @@
     },
     "call_expression": {
       "type": "PREC",
-      "value": 25,
+      "value": 29,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3243,17 +3315,8 @@
             "name": "_immediate_paren"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "argument_list"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "generator_expression"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "argument_list"
           },
           {
             "type": "CHOICE",
@@ -3272,7 +3335,7 @@
     },
     "broadcast_call_expression": {
       "type": "PREC",
-      "value": 25,
+      "value": 29,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3292,17 +3355,8 @@
             "name": "_immediate_paren"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "argument_list"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "generator_expression"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "argument_list"
           },
           {
             "type": "CHOICE",
@@ -3321,7 +3375,7 @@
     },
     "_closed_macrocall_expression": {
       "type": "PREC",
-      "value": 25,
+      "value": 29,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3358,17 +3412,8 @@
             "name": "_immediate_paren"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "argument_list"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "generator_expression"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "argument_list"
           },
           {
             "type": "CHOICE",
@@ -3481,55 +3526,116 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "CHOICE",
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "_expression"
+                            },
+                            {
+                              "type": "ALIAS",
+                              "content": {
+                                "type": "SYMBOL",
+                                "name": "named_field"
+                              },
+                              "named": true,
+                              "value": "named_argument"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "_expression"
+                                  },
+                                  {
+                                    "type": "ALIAS",
+                                    "content": {
+                                      "type": "SYMBOL",
+                                      "name": "named_field"
+                                    },
+                                    "named": true,
+                                    "value": "named_argument"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": ","
+                            },
+                            {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "SEQ",
+                                  "members": [
+                                    {
+                                      "type": "SYMBOL",
+                                      "name": "_expression"
+                                    },
+                                    {
+                                      "type": "SYMBOL",
+                                      "name": "_comprehension_clause"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "BLANK"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "SEQ",
                   "members": [
                     {
                       "type": "SYMBOL",
                       "name": "_expression"
                     },
                     {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "named_field"
-                      },
-                      "named": true,
-                      "value": "named_argument"
+                      "type": "SYMBOL",
+                      "name": "_comprehension_clause"
                     }
                   ]
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "_expression"
-                          },
-                          {
-                            "type": "ALIAS",
-                            "content": {
-                              "type": "SYMBOL",
-                              "name": "named_field"
-                            },
-                            "named": true,
-                            "value": "named_argument"
-                          }
-                        ]
-                      }
-                    ]
-                  }
                 }
               ]
             },
@@ -3841,7 +3947,7 @@
     },
     "interpolation_expression": {
       "type": "PREC_RIGHT",
-      "value": 29,
+      "value": 25,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3867,7 +3973,7 @@
     },
     "quote_expression": {
       "type": "PREC_RIGHT",
-      "value": 29,
+      "value": 25,
       "content": {
         "type": "SEQ",
         "members": [
@@ -4024,12 +4130,122 @@
                         "type": "SEQ",
                         "members": [
                           {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "."
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "+="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "-="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "*="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "/="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "//="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "\\="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "^="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "÷="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "%="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "<<="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": ">>="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": ">>>="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "|="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "&="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "⊻="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "≔"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "⩴"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "≕"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
                             "type": "STRING",
                             "value": "("
                           },
                           {
                             "type": "CHOICE",
                             "members": [
+                              {
+                                "type": "STRING",
+                                "value": "::"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": ":="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": ".="
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "="
+                              },
                               {
                                 "type": "TOKEN",
                                 "content": {
@@ -4055,16 +4271,98 @@
                                 }
                               },
                               {
-                                "type": "STRING",
-                                "value": "::"
-                              },
-                              {
-                                "type": "STRING",
-                                "value": ":="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "="
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "."
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "+="
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "-="
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "*="
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/="
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "//="
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\="
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "^="
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "÷="
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "%="
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "<<="
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ">>="
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ">>>="
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "|="
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "&="
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "⊻="
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "≔"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "⩴"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "≕"
+                                      }
+                                    ]
+                                  }
+                                ]
                               }
                             ]
                           },
@@ -4087,6 +4385,90 @@
                   "content": {
                     "type": "CHOICE",
                     "members": [
+                      {
+                        "type": "STRING",
+                        "value": "baremodule"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "module"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "abstract"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "primitive"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "mutable"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "struct"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "quote"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "let"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "if"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "else"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "elseif"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "try"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "catch"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "finally"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "for"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "while"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "break"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "continue"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "using"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "import"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "const"
+                      },
                       {
                         "type": "STRING",
                         "value": "global"
@@ -4175,16 +4557,24 @@
         },
         {
           "type": "SYMBOL",
+          "name": "where_expression"
+        },
+        {
+          "type": "SYMBOL",
           "name": "operator"
         },
         {
-          "type": "ALIAS",
+          "type": "PREC",
+          "value": -1,
           "content": {
-            "type": "STRING",
-            "value": ":"
-          },
-          "named": true,
-          "value": "operator"
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": ":"
+            },
+            "named": true,
+            "value": "operator"
+          }
         },
         {
           "type": "PREC",
@@ -4203,7 +4593,7 @@
     },
     "adjoint_expression": {
       "type": "PREC",
-      "value": 28,
+      "value": 26,
       "content": {
         "type": "SEQ",
         "members": [
@@ -4223,7 +4613,7 @@
     },
     "unary_expression": {
       "type": "PREC_RIGHT",
-      "value": 29,
+      "value": 25,
       "content": {
         "type": "SEQ",
         "members": [
@@ -4248,7 +4638,7 @@
       "members": [
         {
           "type": "PREC_LEFT",
-          "value": 24,
+          "value": 27,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4450,7 +4840,7 @@
         },
         {
           "type": "PREC_RIGHT",
-          "value": 15,
+          "value": 13,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4567,7 +4957,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 13,
+          "value": 14,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4618,7 +5008,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 14,
+          "value": 15,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4751,23 +5141,41 @@
             "value": "?"
           },
           {
-            "type": "SYMBOL",
-            "name": "_expression"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "assignment"
+              }
+            ]
           },
           {
             "type": "STRING",
             "value": ":"
           },
           {
-            "type": "SYMBOL",
-            "name": "_expression"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "assignment"
+              }
+            ]
           }
         ]
       }
     },
     "typed_expression": {
       "type": "PREC",
-      "value": 26,
+      "value": 28,
       "content": {
         "type": "SEQ",
         "members": [
@@ -4776,17 +5184,8 @@
             "name": "_expression"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "::"
-              },
-              {
-                "type": "STRING",
-                "value": "<:"
-              }
-            ]
+            "type": "STRING",
+            "value": "::"
           },
           {
             "type": "CHOICE",
@@ -4802,7 +5201,7 @@
     },
     "function_expression": {
       "type": "PREC_RIGHT",
-      "value": 15,
+      "value": 13,
       "content": {
         "type": "SEQ",
         "members": [
@@ -4816,6 +5215,15 @@
               {
                 "type": "SYMBOL",
                 "name": "parameter_list"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "typed_expression"
+                },
+                "named": true,
+                "value": "typed_parameter"
               }
             ]
           },
@@ -4844,30 +5252,34 @@
       }
     },
     "juxtaposition_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "integer_literal"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "float_literal"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "adjoint_expression"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_primary_expression"
-        }
-      ]
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "integer_literal"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "float_literal"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "adjoint_expression"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_primary_expression"
+          }
+        ]
+      }
     },
     "compound_assignment_expression": {
       "type": "PREC_RIGHT",
@@ -4887,6 +5299,27 @@
             },
             "named": true,
             "value": "operator"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        ]
+      }
+    },
+    "where_expression": {
+      "type": "PREC_LEFT",
+      "value": 24,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          },
+          {
+            "type": "STRING",
+            "value": "where"
           },
           {
             "type": "SYMBOL",
@@ -6769,7 +7202,7 @@
         ]
       }
     },
-    "_pipe_right_operator": {
+    "_pipe_left_operator": {
       "type": "TOKEN",
       "content": {
         "type": "SEQ",
@@ -6798,7 +7231,7 @@
         ]
       }
     },
-    "_pipe_left_operator": {
+    "_pipe_right_operator": {
       "type": "TOKEN",
       "content": {
         "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -94,10 +94,6 @@
         "named": true
       },
       {
-        "type": "generator_expression",
-        "named": true
-      },
-      {
         "type": "identifier",
         "named": true
       },
@@ -180,6 +176,10 @@
       {
         "type": "vector_expression",
         "named": true
+      },
+      {
+        "type": "where_expression",
+        "named": true
       }
     ]
   },
@@ -261,7 +261,7 @@
       "required": false,
       "types": [
         {
-          "type": "subtype_clause",
+          "type": "type_clause",
           "named": true
         },
         {
@@ -296,6 +296,14 @@
       "types": [
         {
           "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "for_clause",
+          "named": true
+        },
+        {
+          "type": "if_clause",
           "named": true
         },
         {
@@ -404,10 +412,6 @@
           "named": true
         },
         {
-          "type": "generator_expression",
-          "named": true
-        },
-        {
           "type": "identifier",
           "named": true
         },
@@ -492,10 +496,6 @@
         },
         {
           "type": "field_expression",
-          "named": true
-        },
-        {
-          "type": "generator_expression",
           "named": true
         },
         {
@@ -732,7 +732,7 @@
           "named": true
         },
         {
-          "type": "subtype_clause",
+          "type": "type_clause",
           "named": true
         }
       ]
@@ -923,10 +923,6 @@
           },
           {
             "type": "field_expression",
-            "named": true
-          },
-          {
-            "type": "generator_expression",
             "named": true
           },
           {
@@ -1209,10 +1205,6 @@
             "named": true
           },
           {
-            "type": "generator_expression",
-            "named": true
-          },
-          {
             "type": "identifier",
             "named": true
           },
@@ -1329,6 +1321,10 @@
         {
           "type": "parameter_list",
           "named": true
+        },
+        {
+          "type": "typed_parameter",
+          "named": true
         }
       ]
     }
@@ -1377,10 +1373,6 @@
           },
           {
             "type": "field_expression",
-            "named": true
-          },
-          {
-            "type": "generator_expression",
             "named": true
           },
           {
@@ -1440,29 +1432,6 @@
       "types": [
         {
           "type": "where_clause",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "generator_expression",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "_expression",
-          "named": true
-        },
-        {
-          "type": "for_clause",
-          "named": true
-        },
-        {
-          "type": "if_clause",
           "named": true
         }
       ]
@@ -1673,10 +1642,6 @@
           "named": true
         },
         {
-          "type": "generator_expression",
-          "named": true
-        },
-        {
           "type": "identifier",
           "named": true
         },
@@ -1765,10 +1730,6 @@
           "named": true
         },
         {
-          "type": "generator_expression",
-          "named": true
-        },
-        {
           "type": "identifier",
           "named": true
         },
@@ -1833,10 +1794,6 @@
         },
         {
           "type": "float_literal",
-          "named": true
-        },
-        {
-          "type": "generator_expression",
           "named": true
         },
         {
@@ -1908,6 +1865,10 @@
         },
         {
           "type": "interpolation_expression",
+          "named": true
+        },
+        {
+          "type": "macrocall_expression",
           "named": true
         },
         {
@@ -2178,10 +2139,6 @@
         },
         {
           "type": "field_expression",
-          "named": true
-        },
-        {
-          "type": "generator_expression",
           "named": true
         },
         {
@@ -2469,10 +2426,6 @@
           "named": true
         },
         {
-          "type": "generator_expression",
-          "named": true
-        },
-        {
           "type": "identifier",
           "named": true
         },
@@ -2544,7 +2497,15 @@
           "named": true
         },
         {
+          "type": "for_clause",
+          "named": true
+        },
+        {
           "type": "global_declaration",
+          "named": true
+        },
+        {
+          "type": "if_clause",
           "named": true
         },
         {
@@ -2658,7 +2619,7 @@
           "named": true
         },
         {
-          "type": "subtype_clause",
+          "type": "type_clause",
           "named": true
         },
         {
@@ -2698,10 +2659,6 @@
         },
         {
           "type": "float_literal",
-          "named": true
-        },
-        {
-          "type": "generator_expression",
           "named": true
         },
         {
@@ -2974,10 +2931,6 @@
             "named": true
           },
           {
-            "type": "generator_expression",
-            "named": true
-          },
-          {
             "type": "identifier",
             "named": true
           },
@@ -3218,26 +3171,11 @@
           "named": true
         },
         {
-          "type": "subtype_clause",
+          "type": "type_clause",
           "named": true
         },
         {
           "type": "type_parameter_list",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "subtype_clause",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "_expression",
           "named": true
         }
       ]
@@ -3253,6 +3191,10 @@
       "types": [
         {
           "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "assignment",
           "named": true
         }
       ]
@@ -3318,7 +3260,94 @@
           "named": true
         },
         {
+          "type": "for_clause",
+          "named": true
+        },
+        {
+          "type": "if_clause",
+          "named": true
+        },
+        {
           "type": "named_field",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "type_clause",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "broadcast_call_expression",
+          "named": true
+        },
+        {
+          "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "comprehension_expression",
+          "named": true
+        },
+        {
+          "type": "curly_expression",
+          "named": true
+        },
+        {
+          "type": "field_expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "interpolation_expression",
+          "named": true
+        },
+        {
+          "type": "macrocall_expression",
+          "named": true
+        },
+        {
+          "type": "matrix_expression",
+          "named": true
+        },
+        {
+          "type": "parametrized_type_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "prefixed_command_literal",
+          "named": true
+        },
+        {
+          "type": "prefixed_string_literal",
+          "named": true
+        },
+        {
+          "type": "quote_expression",
+          "named": true
+        },
+        {
+          "type": "tuple_expression",
+          "named": true
+        },
+        {
+          "type": "vector_expression",
           "named": true
         }
       ]
@@ -3341,7 +3370,7 @@
           "named": true
         },
         {
-          "type": "subtype_clause",
+          "type": "type_clause",
           "named": true
         }
       ]
@@ -3386,7 +3415,7 @@
       },
       "type": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "broadcast_call_expression",
@@ -3406,10 +3435,6 @@
           },
           {
             "type": "field_expression",
-            "named": true
-          },
-          {
-            "type": "generator_expression",
             "named": true
           },
           {
@@ -3464,9 +3489,13 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "_expression",
+          "named": true
+        },
         {
           "type": "where_clause",
           "named": true
@@ -3537,10 +3566,6 @@
           "named": true
         },
         {
-          "type": "generator_expression",
-          "named": true
-        },
-        {
           "type": "identifier",
           "named": true
         },
@@ -3581,15 +3606,30 @@
           "named": true
         },
         {
-          "type": "subtype_clause",
-          "named": true
-        },
-        {
           "type": "tuple_expression",
           "named": true
         },
         {
+          "type": "type_clause",
+          "named": true
+        },
+        {
           "type": "vector_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "where_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_expression",
           "named": true
         }
       ]
@@ -3702,6 +3742,10 @@
     "named": false
   },
   {
+    "type": ">:",
+    "named": false
+  },
+  {
     "type": "?",
     "named": false
   },
@@ -3715,10 +3759,6 @@
   },
   {
     "type": "]",
-    "named": false
-  },
-  {
-    "type": "abstract",
     "named": false
   },
   {
@@ -3842,10 +3882,6 @@
     "named": false
   },
   {
-    "type": "primitive",
-    "named": false
-  },
-  {
     "type": "quote",
     "named": false
   },
@@ -3863,10 +3899,6 @@
   },
   {
     "type": "try",
-    "named": false
-  },
-  {
-    "type": "type",
     "named": false
   },
   {

--- a/test/corpus/collections.txt
+++ b/test/corpus/collections.txt
@@ -157,6 +157,8 @@ comprehension array collections
   if x > 0
 ]
 UInt[b(c, e) for c in d for e in f]
+
+f(1, 2, i for i in iter)
 (b(c, e) for c in d, e = 5 if e)
 
 ---
@@ -165,6 +167,7 @@ UInt[b(c, e) for c in d for e in f]
   (comprehension_expression
     (identifier)
     (for_clause (for_binding (identifier) (identifier))))
+
   (comprehension_expression
     (identifier)
     (for_clause (for_binding (identifier) (identifier)))
@@ -175,7 +178,15 @@ UInt[b(c, e) for c in d for e in f]
       (call_expression (identifier) (argument_list (identifier) (identifier)))
       (for_clause (for_binding (identifier) (identifier)))
       (for_clause (for_binding (identifier) (identifier)))))
-  (generator_expression
+
+  (call_expression
+    (identifier)
+    (argument_list
+      (integer_literal)
+      (integer_literal)
+      (identifier)
+      (for_clause (for_binding (identifier) (identifier)))))
+  (parenthesized_expression
     (call_expression (identifier) (argument_list (identifier) (identifier)))
     (for_clause
       (for_binding (identifier) (identifier))

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -41,7 +41,7 @@ abstract type T{S} <: U end
 
   (primitive_definition
     (identifier)
-    (subtype_clause (identifier))
+    (type_clause (identifier))
     (integer_literal))
 
   (primitive_definition
@@ -55,13 +55,13 @@ abstract type T{S} <: U end
 
   (abstract_definition
     (identifier)
-    (subtype_clause (identifier)))
+    (type_clause (identifier)))
 
   (abstract_definition
     (identifier)
     (type_parameter_list
       (identifier))
-    (subtype_clause (identifier))))
+    (type_clause (identifier))))
 
 
 ==============================
@@ -118,15 +118,16 @@ end
   ;; Parametric subtypes
   (struct_definition
     (identifier)
-    (type_parameter_list (typed_expression (identifier) (identifier)))
-    (subtype_clause (identifier))
+    (type_parameter_list
+      (binary_expression (identifier) (operator) (identifier)))
+    (type_clause (identifier))
     (typed_expression (identifier) (identifier))
     (typed_expression (identifier) (identifier)))
 
   ;; Parametric fields
   (struct_definition
     (identifier)
-    (subtype_clause (identifier))
+    (type_clause (identifier))
     (typed_expression
       (identifier)
       (parametrized_type_expression
@@ -461,8 +462,9 @@ Base.show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m,
                     type: (identifier)))
     (where_clause
       (curly_expression
-        (typed_expression
+        (binary_expression
           (identifier)
+          (operator)
           (identifier))))
     (identifier))
 
@@ -478,13 +480,15 @@ Base.show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m,
                     type: (identifier)))
     (where_clause
       (curly_expression
-        (typed_expression
+        (binary_expression
           (identifier)
+          (operator)
           (identifier))))
     (where_clause
       (curly_expression
-        (typed_expression
+        (binary_expression
           (identifier)
+          (operator)
           (identifier))))
     (binary_expression
       (identifier)
@@ -514,7 +518,7 @@ Base.show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m,
                             (curly_expression (identifier)))
                     (where_clause
                       (identifier)
-                      (subtype_clause
+                      (type_clause
                         (identifier)))))
     (call_expression (identifier) (argument_list (identifier))))
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -120,7 +120,7 @@ $(usertype){T}
     (curly_expression (identifier)))
   (parametrized_type_expression
     (identifier)
-    (curly_expression (subtype_clause (identifier))))
+    (curly_expression (type_clause (identifier))))
   (parametrized_type_expression
     (interpolation_expression (parenthesized_expression (identifier)))
     (curly_expression (identifier)))

--- a/test/corpus/operators.txt
+++ b/test/corpus/operators.txt
@@ -102,8 +102,9 @@ a & b | c
 
 Dict(b => c, d => e)
 
-a |>
-b
+x |>
+  f |>
+  g
 
 1..10
 (1:10...,)
@@ -132,9 +133,12 @@ b
 
   ; Pipes (and newline)
   (binary_expression
-    (identifier)
-    (operator)
-    (identifier))
+    (binary_expression
+      (identifier)
+      (operator)
+      (identifier))
+      (operator)
+      (identifier))
 
   ; Ellipses
   (binary_expression
@@ -186,6 +190,7 @@ unary operators
 ==============================
 
 [a, b]'
+-A'
 +a
 -b
 √9
@@ -195,6 +200,7 @@ unary operators
 ---
 (source_file
   (adjoint_expression (vector_expression (identifier) (identifier)))
+  (unary_expression (operator) (adjoint_expression (identifier)))
   (unary_expression (operator) (identifier))
   (unary_expression (operator) (identifier))
   (unary_expression (operator) (integer_literal))


### PR DESCRIPTION
#### Type operators
- Rename `subtype_clause` to `type_clause` :
  - Remove subtype operator from `typed_expression`.
  - Add supertype operator to `type_clause`.
  - Note that outside definitions, both `<:` and `>:` are parsed as comparison operators.
- Add `where_expression`:
  The rule `where_clause` is still needed because `where` has a different precedence depending on whether it's in a definition / type parameter or if it's a regular expression.
 
#### Quotes
- Add assignment operators to quote_expression.
- Change precedence of colon `:` as identifier.
- Parse `primitive type` and `abstract type` as a single token.
  This enables parsing `primitive` and `abstract` as identifiers.
- Add a list of keywords:
   This enables quoting some keywords without tree-sitter trying to parse their corresponding rule. This can still fail depending on the context, but in most cases it's good enough.

#### Misc
- Add typed parameters to `function_expression`.
- Add closed macros to `keyword_parameters` (they're already allowed in regular parameters).
- Add assignments to `ternary_expression`.
- Remove `generator_expression` and allow a trailing `_comprehension_clause` in any collection.
- Fix arrow, prefix and postfix precedences.
- Fix pipes names.