### PR TITLE
Use `_immediate_*` rules in macrocalls and quotations

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -970,7 +970,6 @@ module.exports = grammar({
       choice(
         $._expression,
         $.assignment,
-        $.bare_tuple,
       )
     )),
 

--- a/grammar.js
+++ b/grammar.js
@@ -482,9 +482,9 @@ module.exports = grammar({
       'end'
     ),
 
-    break_statement: $ => 'break',
+    break_statement: _ => 'break',
 
-    continue_statement: $ => 'continue',
+    continue_statement: _ => 'continue',
 
     return_statement: $ => prec.right(PREC_DECL, seq(
       'return',
@@ -626,8 +626,8 @@ module.exports = grammar({
     vector_expression: $ => seq(
       '[',
       sep(',', choice(
-      $._expression,
-      alias($.named_field, $.assignment), // JuMP.jl
+        $._expression,
+        alias($.named_field, $.assignment), // JuMP.jl
       )),
       optional(','),
       ']'
@@ -1084,7 +1084,7 @@ module.exports = grammar({
       ),
     ),
 
-    identifier: $ => {
+    identifier: _ => {
       const operators = [
         '$',
         '&',
@@ -1147,16 +1147,16 @@ module.exports = grammar({
       $.command_literal,
     ),
 
-    boolean_literal: $ => choice('true', 'false'),
+    boolean_literal: _ => choice('true', 'false'),
 
-    integer_literal: $ => choice(
+    integer_literal: _ => choice(
       token(seq('0b', numeral('01'))),
       token(seq('0o', numeral('0-7'))),
       token(seq('0x', numeral('0-9a-fA-F'))),
       numeral('0-9'),
     ),
 
-    float_literal: $ => {
+    float_literal: _ => {
       const dec = numeral('0-9');
       const hex = numeral('0-9a-fA-F');
       const exponent = /[eEf][+-]?\d+/;
@@ -1191,9 +1191,9 @@ module.exports = grammar({
       return choice(leading_period, trailing_period, just_exponent, hex_float);
     },
 
-    escape_sequence: $ => ESCAPE_SEQUENCE,
+    escape_sequence: _ => ESCAPE_SEQUENCE,
 
-    character_literal: $ => token(seq(
+    character_literal: _ => token(seq(
       "'",
       choice(
         /[^'\\]/,
@@ -1241,35 +1241,35 @@ module.exports = grammar({
       ),
     ),
 
-    _unary_operator: $ => token(addDots('+ - ! ~ ¬ √ ∛ ∜')),
+    _unary_operator: _ => token(addDots('+ - ! ~ ¬ √ ∛ ∜')),
 
-    _power_operator: $ => token(addDots(POWER_OPERATORS)),
+    _power_operator: _ => token(addDots(POWER_OPERATORS)),
 
-    _bitshift_operator: $ => token(addDots(BITSHIFT_OPERATORS)),
+    _bitshift_operator: _ => token(addDots(BITSHIFT_OPERATORS)),
 
-    _rational_operator: $ => token(addDots('//')),
+    _rational_operator: _ => token(addDots('//')),
 
-    _times_operator: $ => token(addDots(TIMES_OPERATORS)),
+    _times_operator: _ => token(addDots(TIMES_OPERATORS)),
 
-    _plus_operator: $ => token(addDots(PLUS_OPERATORS)),
+    _plus_operator: _ => token(addDots(PLUS_OPERATORS)),
 
-    _ellipsis_operator: $ => token(choice('..', addDots(ELLIPSIS_OPERATORS))),
+    _ellipsis_operator: _ => token(choice('..', addDots(ELLIPSIS_OPERATORS))),
 
-    _pipe_left_operator: $ => token(addDots('<|')),
+    _pipe_left_operator: _ => token(addDots('<|')),
 
-    _pipe_right_operator: $ => token(addDots('|>')),
+    _pipe_right_operator: _ => token(addDots('|>')),
 
-    _comparison_operator: $ => token(choice('<:', '>:', addDots(COMPARISON_OPERATORS))),
+    _comparison_operator: _ => token(choice('<:', '>:', addDots(COMPARISON_OPERATORS))),
 
-    _arrow_operator: $ => token(choice('<--', '-->', '<-->', addDots(ARROW_OPERATORS))),
+    _arrow_operator: _ => token(choice('<--', '-->', '<-->', addDots(ARROW_OPERATORS))),
 
-    _pair_operator: $ => token(addDots('=>')),
+    _pair_operator: _ => token(addDots('=>')),
 
-    _assign_operator: $ => token(choice(':=', '~', '$=', '.=', addDots(ASSIGN_OPERATORS))),
+    _assign_operator: _ => token(choice(':=', '~', '$=', '.=', addDots(ASSIGN_OPERATORS))),
 
-    _terminator: $ => choice('\n', /;+/),
+    _terminator: _ => choice('\n', /;+/),
 
-    line_comment: $ => token(seq('#', /.*/))
+    line_comment: _ => token(seq('#', /.*/))
   }
 });
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2254,12 +2254,29 @@
       "members": [
         {
           "type": "SYMBOL",
+          "name": "_array"
+        },
+        {
+          "type": "SYMBOL",
           "name": "identifier"
         },
         {
           "type": "SYMBOL",
           "name": "curly_expression"
         },
+        {
+          "type": "SYMBOL",
+          "name": "parenthesized_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "tuple_expression"
+        }
+      ]
+    },
+    "_array": {
+      "type": "CHOICE",
+      "members": [
         {
           "type": "SYMBOL",
           "name": "comprehension_expression"
@@ -2271,14 +2288,6 @@
         {
           "type": "SYMBOL",
           "name": "vector_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "parenthesized_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "tuple_expression"
         }
       ]
     },
@@ -2739,27 +2748,6 @@
         {
           "type": "STRING",
           "value": "]"
-        }
-      ]
-    },
-    "generator_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_comprehension_clause"
-        },
-        {
-          "type": "STRING",
-          "value": ")"
         }
       ]
     },
@@ -3256,21 +3244,8 @@
           "name": "_immediate_bracket"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "comprehension_expression"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "matrix_expression"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "vector_expression"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_array"
         }
       ]
     },
@@ -3408,22 +3383,58 @@
             "name": "macro_identifier"
           },
           {
-            "type": "SYMBOL",
-            "name": "_immediate_paren"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "argument_list"
-          },
-          {
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "do_clause"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_immediate_brace"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "curly_expression"
+                  }
+                ]
               },
               {
-                "type": "BLANK"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_immediate_bracket"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_array"
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_immediate_paren"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "argument_list"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "do_clause"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -3990,11 +4001,277 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "_quotable"
+                "name": "identifier"
               },
               {
                 "type": "SYMBOL",
                 "name": "operator"
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_immediate_brace"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "curly_expression"
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_immediate_bracket"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_array"
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_immediate_paren"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "parenthesized_expression"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "tuple_expression"
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "("
+                          },
+                          {
+                            "type": "ALIAS",
+                            "content": {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "::"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": ":="
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": ".="
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "="
+                                  },
+                                  {
+                                    "type": "TOKEN",
+                                    "content": {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "."
+                                            },
+                                            {
+                                              "type": "BLANK"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "&&"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "type": "TOKEN",
+                                    "content": {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "."
+                                            },
+                                            {
+                                              "type": "BLANK"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "||"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "type": "TOKEN",
+                                    "content": {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "$"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "->"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "."
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "..."
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "."
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "+="
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "-="
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "*="
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/="
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "//="
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\="
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "^="
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "÷="
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "%="
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "<<="
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": ">>="
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": ">>>="
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "|="
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "&="
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "⊻="
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "≔"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "⩴"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "≕"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "named": true,
+                            "value": "operator"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": ")"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               },
               {
                 "type": "ALIAS",
@@ -4217,158 +4494,6 @@
                                 "value": "≕"
                               }
                             ]
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "("
-                          },
-                          {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": "::"
-                              },
-                              {
-                                "type": "STRING",
-                                "value": ":="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": ".="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "="
-                              },
-                              {
-                                "type": "TOKEN",
-                                "content": {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "STRING",
-                                      "value": "$"
-                                    },
-                                    {
-                                      "type": "STRING",
-                                      "value": "->"
-                                    },
-                                    {
-                                      "type": "STRING",
-                                      "value": "."
-                                    },
-                                    {
-                                      "type": "STRING",
-                                      "value": "..."
-                                    }
-                                  ]
-                                }
-                              },
-                              {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "."
-                                      },
-                                      {
-                                        "type": "BLANK"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "+="
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": "-="
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": "*="
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": "/="
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": "//="
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\="
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": "^="
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": "÷="
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": "%="
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": "<<="
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": ">>="
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": ">>>="
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": "|="
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": "&="
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": "⊻="
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": "≔"
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": "⩴"
-                                      },
-                                      {
-                                        "type": "STRING",
-                                        "value": "≕"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "type": "STRING",
-                            "value": ")"
                           }
                         ]
                       }
@@ -5241,10 +5366,6 @@
               {
                 "type": "SYMBOL",
                 "name": "assignment"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "bare_tuple"
               }
             ]
           }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1315,10 +1315,6 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
           "type": "parameter_list",
           "named": true
         },

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -195,47 +195,38 @@ end
 
 
 ==============================
-macro expressions
+macro call expressions
 ==============================
 
-@enum(Light, red, yellow, green)
-
-joinpath(@__DIR__, "grammar.js")
-
 @assert x == y "a message"
-
-@. a * x + b
 
 @testset "a" begin
   b = c
 end
+
+@. a * x + b
+
+joinpath(@__DIR__, "grammar.js")
 
 @macroexpand @async accept(socket)
 
 @Meta.dump 1, 2
 Meta.@dump x = 1
 
-f(@nospecialize(x)) = x
-
-
 ---
 
 (source_file
   (macrocall_expression
     (macro_identifier (identifier))
-    (argument_list (identifier) (identifier) (identifier) (identifier)))
-
-  (call_expression
-    (identifier)
-    (argument_list
-      (macrocall_expression (macro_identifier (identifier)))
+    (macro_argument_list
+      (binary_expression (identifier) (operator) (identifier))
       (string_literal)))
 
   (macrocall_expression
     (macro_identifier (identifier))
     (macro_argument_list
-      (binary_expression (identifier) (operator) (identifier))
-      (string_literal)))
+      (string_literal)
+      (compound_statement (assignment (identifier) (operator) (identifier)))))
 
   (macrocall_expression
     (macro_identifier (operator))
@@ -245,12 +236,14 @@ f(@nospecialize(x)) = x
         (operator)
         (identifier))))
 
-  (macrocall_expression
-    (macro_identifier (identifier))
-    (macro_argument_list
-      (string_literal)
-      (compound_statement (assignment (identifier) (operator) (identifier)))))
+  ; Macros as arguments
+  (call_expression
+    (identifier)
+    (argument_list
+      (macrocall_expression (macro_identifier (identifier)))
+      (string_literal)))
 
+  ; Nested macros
   (macrocall_expression
     (macro_identifier (identifier))
     (macro_argument_list
@@ -259,24 +252,57 @@ f(@nospecialize(x)) = x
         (macro_argument_list
           (call_expression (identifier) (argument_list (identifier)))))))
 
+  ; Scoped macro identifiers
   (macrocall_expression
     (macro_identifier (scoped_identifier (identifier) (identifier)))
     (macro_argument_list
       (bare_tuple (integer_literal) (integer_literal))))
-
   (macrocall_expression
     (identifier)
     (macro_identifier (identifier))
     (macro_argument_list
-      (assignment (identifier) (operator) (integer_literal))))
+      (assignment (identifier) (operator) (integer_literal)))))
 
+
+==============================
+closed macro call expressions
+==============================
+
+@enum(Light, red, yellow, green)
+f(@nospecialize(x)) = x
+
+@m[1, 2] + 1
+@m [1, 2] + 1
+
+---
+(source_file
+  (macrocall_expression
+    (macro_identifier (identifier))
+    (argument_list (identifier) (identifier) (identifier) (identifier)))
+
+  ; Macros as parameters
   (short_function_definition
     (identifier)
     (parameter_list
       (macrocall_expression
         (macro_identifier (identifier))
         (argument_list (identifier))))
-    (identifier)))
+    (identifier))
+
+  ; Open vs closed macros
+  (binary_expression
+    (macrocall_expression
+      (macro_identifier (identifier))
+      (vector_expression (integer_literal) (integer_literal)))
+    (operator)
+    (integer_literal))
+  (macrocall_expression
+    (macro_identifier (identifier))
+    (macro_argument_list
+      (binary_expression
+        (vector_expression (integer_literal) (integer_literal))
+        (operator)
+        (integer_literal)))))
 
 
 ==============================


### PR DESCRIPTION
- Add `_array` rule for matrices, vectors and comprehensions.
- Extend closed macrocalls to work with braces and brackets.
- Refactor `_quote_expression` to use separate `_immediate_*` rules for
  each quotable, and to improve the parsing of syntactic operators.
- Update tests for macro calls.
- Disallow bare tuples in function_expression RHS.
- Use `_` instead of `$` to clarify which expressions are terminals.