### PR TITLE
Refactor export/import rules and adjoint

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -894,7 +894,7 @@ module.exports = grammar({
     ),
 
     adjoint_expression: $ => prec(PREC.postfix, seq(
-      $._expression,
+      $._primary_expression,
       token.immediate("'"),
     )),
 

--- a/grammar.js
+++ b/grammar.js
@@ -495,27 +495,21 @@ module.exports = grammar({
       ))
     )),
 
-    export_statement: $ => seq(
-      'export',
-      prec.right(sep1(',', choice(
-        $.identifier,
-        $.macro_identifier,
-        $.operator,
-        parenthesize(choice($.identifier, $.operator)),
-        $.interpolation_expression,
-      ))),
+    _exportable: $ => choice(
+      $.identifier,
+      $.macro_identifier,
+      $.operator,
+      $.interpolation_expression,
+      parenthesize(choice($.identifier, $.operator)),
     ),
 
-    import_statement: $ => seq(
-      choice('import', 'using'),
-      choice(
-        $._import_list,
-        $.selected_import,
-      ),
+    export_statement: $ => seq(
+      'export',
+      prec.right(sep1(',', $._exportable)),
     ),
 
     relative_qualifier: $ => seq(
-      repeat1('.'),
+      token(repeat1('.')),
       choice(
         $.identifier,
         $.scoped_identifier,
@@ -523,11 +517,9 @@ module.exports = grammar({
     ),
 
     _importable: $ => choice(
-      $.identifier,
+      $._exportable,
       $.scoped_identifier,
       $.relative_qualifier,
-      parenthesize(choice($.identifier, $.operator)),
-      $.interpolation_expression,
     ),
 
     import_alias: $ => seq($._importable, 'as', $.identifier),
@@ -540,12 +532,15 @@ module.exports = grammar({
     selected_import: $ => seq(
       $._importable,
       token.immediate(':'),
-      prec.right(sep1(',', choice(
-        $._importable,
-        $.import_alias,
-        $.macro_identifier,
-        $.operator,
-      )))
+      $._import_list,
+    ),
+
+    import_statement: $ => seq(
+      choice('import', 'using'),
+      choice(
+        $._import_list,
+        $.selected_import,
+      ),
     ),
 
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1879,187 +1879,7 @@
         ]
       }
     },
-    "export_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "export"
-        },
-        {
-          "type": "PREC_RIGHT",
-          "value": 0,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "macro_identifier"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "operator"
-                  },
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "("
-                      },
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "identifier"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "operator"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "STRING",
-                        "value": ")"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "interpolation_expression"
-                  }
-                ]
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ","
-                    },
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "identifier"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "macro_identifier"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "operator"
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "("
-                            },
-                            {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "identifier"
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "operator"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "STRING",
-                              "value": ")"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation_expression"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      ]
-    },
-    "import_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "import"
-            },
-            {
-              "type": "STRING",
-              "value": "using"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_import_list"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "selected_import"
-            }
-          ]
-        }
-      ]
-    },
-    "relative_qualifier": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "REPEAT1",
-          "content": {
-            "type": "STRING",
-            "value": "."
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "scoped_identifier"
-            }
-          ]
-        }
-      ]
-    },
-    "_importable": {
+    "_exportable": {
       "type": "CHOICE",
       "members": [
         {
@@ -2068,11 +1888,15 @@
         },
         {
           "type": "SYMBOL",
-          "name": "scoped_identifier"
+          "name": "macro_identifier"
         },
         {
           "type": "SYMBOL",
-          "name": "relative_qualifier"
+          "name": "operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "interpolation_expression"
         },
         {
           "type": "SEQ",
@@ -2099,10 +1923,89 @@
               "value": ")"
             }
           ]
+        }
+      ]
+    },
+    "export_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "export"
+        },
+        {
+          "type": "PREC_RIGHT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_exportable"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_exportable"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "relative_qualifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "REPEAT1",
+            "content": {
+              "type": "STRING",
+              "value": "."
+            }
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "scoped_identifier"
+            }
+          ]
+        }
+      ]
+    },
+    "_importable": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_exportable"
         },
         {
           "type": "SYMBOL",
-          "name": "interpolation_expression"
+          "name": "scoped_identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "relative_qualifier"
         }
       ]
     },
@@ -2185,67 +2088,39 @@
           }
         },
         {
-          "type": "PREC_RIGHT",
-          "value": 0,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_importable"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "import_alias"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "macro_identifier"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "operator"
-                  }
-                ]
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ","
-                    },
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "_importable"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "import_alias"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "macro_identifier"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "operator"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          }
+          "type": "SYMBOL",
+          "name": "_import_list"
+        }
+      ]
+    },
+    "import_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "import"
+            },
+            {
+              "type": "STRING",
+              "value": "using"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_import_list"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "selected_import"
+            }
+          ]
         }
       ]
     },
@@ -4724,7 +4599,7 @@
         "members": [
           {
             "type": "SYMBOL",
-            "name": "_expression"
+            "name": "_primary_expression"
           },
           {
             "type": "IMMEDIATE_TOKEN",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -280,7 +280,71 @@
       "required": true,
       "types": [
         {
-          "type": "_expression",
+          "type": "broadcast_call_expression",
+          "named": true
+        },
+        {
+          "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "comprehension_expression",
+          "named": true
+        },
+        {
+          "type": "curly_expression",
+          "named": true
+        },
+        {
+          "type": "field_expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "interpolation_expression",
+          "named": true
+        },
+        {
+          "type": "macrocall_expression",
+          "named": true
+        },
+        {
+          "type": "matrix_expression",
+          "named": true
+        },
+        {
+          "type": "parametrized_type_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "prefixed_command_literal",
+          "named": true
+        },
+        {
+          "type": "prefixed_string_literal",
+          "named": true
+        },
+        {
+          "type": "quote_expression",
+          "named": true
+        },
+        {
+          "type": "tuple_expression",
+          "named": true
+        },
+        {
+          "type": "vector_expression",
           "named": true
         }
       ]
@@ -1556,6 +1620,10 @@
           "named": true
         },
         {
+          "type": "macro_identifier",
+          "named": true
+        },
+        {
           "type": "operator",
           "named": true
         },
@@ -1588,6 +1656,10 @@
         },
         {
           "type": "interpolation_expression",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         },
         {


### PR DESCRIPTION
- Add `_exportable` rule.
- Refactor `_importable` to be a superset `_exportable`.
- Refactor `selected_import` to use `_import_list` rule.
- Fix `adjoint_expression`.