### PR TITLE
Allow function definitions in `local` and `global` declarations

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1041,6 +1041,8 @@ module.exports = grammar({
         $.bare_tuple,
         $.identifier,
         $.typed_expression,
+        $.function_definition,
+        $.short_function_definition,
       ),
     )),
 
@@ -1051,6 +1053,8 @@ module.exports = grammar({
         $.bare_tuple,
         $.identifier,
         $.typed_expression,
+        $.function_definition,
+        $.short_function_definition,
       ),
     )),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5491,6 +5491,14 @@
               {
                 "type": "SYMBOL",
                 "name": "typed_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "function_definition"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "short_function_definition"
               }
             ]
           }
@@ -5525,6 +5533,14 @@
               {
                 "type": "SYMBOL",
                 "name": "typed_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "function_definition"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "short_function_definition"
               }
             ]
           }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1514,7 +1514,15 @@
           "named": true
         },
         {
+          "type": "function_definition",
+          "named": true
+        },
+        {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "short_function_definition",
           "named": true
         },
         {
@@ -2033,7 +2041,15 @@
           "named": true
         },
         {
+          "type": "function_definition",
+          "named": true
+        },
+        {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "short_function_definition",
           "named": true
         },
         {

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -331,6 +331,8 @@ local declarations
 
 local x
 local y, z = 1, 2
+local foo() = 3
+local function bar() 4 end
 
 ---
 
@@ -340,7 +342,13 @@ local y, z = 1, 2
     (assignment
     (bare_tuple (identifier) (identifier))
     (operator)
-    (bare_tuple (integer_literal) (integer_literal)))))
+    (bare_tuple (integer_literal) (integer_literal))))
+  (local_declaration
+    (short_function_definition
+      (identifier) (parameter_list) (integer_literal)))
+  (local_declaration
+    (function_definition
+      (identifier) (parameter_list) (integer_literal))))
 
 
 ===============================
@@ -349,6 +357,8 @@ global declarations
 
 global X
 global Y, Z = 11, 42
+global foo() = 3
+global function bar() 4 end
 
 ---
 
@@ -358,4 +368,10 @@ global Y, Z = 11, 42
     (assignment
     (bare_tuple (identifier) (identifier))
     (operator)
-    (bare_tuple (integer_literal) (integer_literal)))))
+    (bare_tuple (integer_literal) (integer_literal))))
+  (global_declaration
+    (short_function_definition
+      (identifier) (parameter_list) (integer_literal)))
+  (global_declaration
+    (function_definition
+      (identifier) (parameter_list) (integer_literal))))


### PR DESCRIPTION
Defining functions with local or global declarations works for julia parser, and it can be useful in certain cases:

```julia
In [25]: let
             global foo() = 1
             let
                 local foo() = 2
             end
         end
Out[25]: #7#foo (generic function with 1 method)
```
and https://github.com/JuliaLang/julia/blob/master/base/coreio.jl.