### PR TITLE
Refactor strings, operators and simple statements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing guide
+
+The two main ways to help the project are reporting and fixing bugs.
+
+
+## Report bugs
+
+To report a bug, you can file an [issue on gitHub](https://github.com/tree-sitter/tree-sitter-julia/issues).
+If possible, the issue should include an brief explanation of the bug, the expected behavior, and a minimal reproducible example.
+
+If your text editor isn't highlighting code correctly, the error might be in the editor or in the parser.
+The best way to check if it's an error in the parser is to read the generated syntax tree of the erroneously highlighted code.
+Some editors have can display the syntax tree of a text file.
+For example, Neovim has the [`:InspectTree`](https://neovim.io/doc/user/treesitter.html#vim.treesitter.inspect_tree()) command.
+
+If the syntax tree has `ERROR` nodes for valid Julia programs, then you should file an issue here.
+Otherwise, if the syntax tree appears to be correct, the issue might be with the queries used by the text editor.
+In that case, you can file an issue in the corresponding issue tracker.
+
+
+## Build and develop
+
+tree-sitter-julia follows the usual structure of a tree-sitter project.
+To get started, you should read the [Creating parsers](https://tree-sitter.github.io/tree-sitter/creating-parsers) section of the tree-sitter docs.
+
+The grammar is mostly done feature-wise, but optimizations in build size and compilation speed are very welcome.
+Currently the grammar takes a while to compile (about 1 minute).
+
+Every new feature or bug fix should include tests. This helps us document supported syntax, check edge cases, and avoid regressions.
+
+
+## Neovim specific details
+
+The Julia queries used in Neovim are in the nvim-treesitter repository:
+- [Queries](https://github.com/nvim-treesitter/nvim-treesitter/tree/master/queries/julia)
+- [CONTRIBUTING.md](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md)
+
+If you want to use your locally built Julia parser in Neovim, you can copy the following snippet
+to your configuration _before_ you call `require('nvim-treesitter.configs').setup`.
+
+```lua
+require("nvim-treesitter.parsers").get_parser_configs().julia = {
+  install_info = {
+    url = "~/path/to/your/fork/of/tree-sitter-julia/",
+    files = { "src/parser.c", "src/scanner.c" },
+  }
+}
+```
+
+You'll have to modify the tree-sitter queries according to the changes you've made in the grammar,
+otherwise you might get highlighting errors.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-tree-sitter-julia
-=================
+# tree-sitter-julia
 
 [![Build/test](https://github.com/tree-sitter/tree-sitter-julia/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/tree-sitter/tree-sitter-julia/actions/workflows/ci.yml)
 
 Julia grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter).
 
-References
+### References
 
 * [The Julia Parser](https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm)
+* [Julia ASTs documentation](https://docs.julialang.org/en/v1/devdocs/ast/)
+* [JuliaSyntax.jl](https://julialang.github.io/JuliaSyntax.jl/dev/)

--- a/grammar.js
+++ b/grammar.js
@@ -83,8 +83,6 @@ const OPERATORS = {
   unary_plus: '+ - ± ∓',
 };
 
-const SYNTACTIC_OPERATOR = token(choice('$', '->', '.', '...'));
-
 const ESCAPE_SEQUENCE = token(seq(
   '\\',
   choice(
@@ -928,10 +926,10 @@ module.exports = grammar({
             alias(
               choice(
                 '::', ':=', '.=', '=',
-                SYNTACTIC_OPERATOR,
+                $._assignment_operator,
                 $._lazy_or_operator,
                 $._lazy_and_operator,
-                $._assignment_operator,
+                $._syntactic_operator,
               ),
               $.operator,
             ),
@@ -940,10 +938,10 @@ module.exports = grammar({
         // Syntactic operators without parentheses
         alias(
           choice(
-            SYNTACTIC_OPERATOR,
+            $._assignment_operator,
             $._lazy_or_operator,
             $._lazy_and_operator,
-            $._assignment_operator,
+            $._syntactic_operator,
           ),
           $.operator,
         ),
@@ -1070,9 +1068,9 @@ module.exports = grammar({
 
     macro_identifier: $ => seq('@', choice(
       $.identifier,
-      $.operator,
       $.scoped_identifier,
-      alias(token.immediate('.'), $.operator)
+      $.operator,
+      alias($._syntactic_operator, $.operator),
     )),
 
     scoped_identifier: $ => seq(
@@ -1277,6 +1275,9 @@ module.exports = grammar({
     _unary_operator: _ => token(addDots(OPERATORS.unary)),
 
     _unary_plus_operator: _ => token(addDots(OPERATORS.unary_plus)),
+
+
+    _syntactic_operator: _ => token(choice('$', '.', '...', '->', '?')),
 
 
     _terminator: _ => choice('\n', /;+/),

--- a/grammar.js
+++ b/grammar.js
@@ -25,7 +25,7 @@ const PREC = [
   return result;
 }, {});
 
-PREC.mat_elem = -1;
+PREC.array = -1;
 PREC.tuple = -1; // Bare tuples
 PREC.assign = -2;
 PREC.stmt = -3;
@@ -643,7 +643,7 @@ module.exports = grammar({
       $.vector_expression,
     ),
 
-    comprehension_expression: $ => prec(PREC.mat_elem, seq(
+    comprehension_expression: $ => prec(PREC.array, seq(
       '[',
       choice(
         $._expression,
@@ -685,7 +685,7 @@ module.exports = grammar({
       $._expression
     ),
 
-    matrix_expression: $ => prec(PREC.mat_elem, seq(
+    matrix_expression: $ => prec(PREC.array, seq(
       '[',
       choice(
         // Must allow newlines even if there's already a semicolon.
@@ -697,7 +697,7 @@ module.exports = grammar({
       ']'
     )),
 
-    matrix_row: $ => repeat1(prec(PREC.mat_elem, choice(
+    matrix_row: $ => repeat1(prec(PREC.array, choice(
       $._expression,
       alias($.named_field, $.assignment), // JuMP.jl
     ))),

--- a/grammar.js
+++ b/grammar.js
@@ -131,6 +131,7 @@ module.exports = grammar({
     $._terminator,
     $._definition,
     $._statement,
+    $._operation,
   ],
 
   externals: $ => [
@@ -209,6 +210,19 @@ module.exports = grammar({
         $.short_function_definition,
       )),
       optional($._terminator)
+    ),
+
+    _expression: $ => choice(
+      // All previous rules are expressions
+      $._definition,
+      $._statement,
+      $._number,
+      $._primary_expression,
+      $._operation,
+      $.macrocall_expression,
+      $.operator,
+      prec(-1, alias(':', $.operator)),
+      prec(-1, alias('begin', $.identifier)),
     ),
 
     // Definitions
@@ -871,28 +885,22 @@ module.exports = grammar({
       ),
     )),
 
-    // Expressions
+    // Operations
 
-    _expression: $ => choice(
-      // All previous rules are expressions
-      $._definition,
-      $._statement,
-      $._number,
-      $._primary_expression,
-      $.macrocall_expression,
+    _operation: $ => choice(
+      // Use regular operators
       $.unary_expression,
       $.binary_expression,
       $.range_expression,
+      // Use syntactic operators
       $.splat_expression,
       $.ternary_expression,
       $.typed_expression,
       $.function_expression,
+      // Other stuff
       $.juxtaposition_expression,
       $.compound_assignment_expression,
       $.where_expression,
-      $.operator,
-      prec(-1, alias(':', $.operator)),
-      prec(-1, alias('begin', $.identifier)),
     ),
 
     unary_expression: $ => prec.right(PREC.prefix, seq(

--- a/grammar.js
+++ b/grammar.js
@@ -182,7 +182,7 @@ module.exports = grammar({
     [$.matrix_row, $.comprehension_expression],
 
     [$.juxtaposition_expression, $._number],
-    [$.juxtaposition_expression, $._expression], // adjoint
+    [$.juxtaposition_expression, $._primary_expression], // adjoint
   ],
 
   supertypes: $ => [
@@ -680,6 +680,7 @@ module.exports = grammar({
     // Primary expressions can be called, indexed, accessed, and type parametrized.
     _primary_expression: $ => choice(
       $._quotable,
+      $.adjoint_expression,
       $.broadcast_call_expression,
       $.call_expression,
       alias($._closed_macrocall_expression, $.macrocall_expression),
@@ -689,6 +690,11 @@ module.exports = grammar({
       $.interpolation_expression,
       $.quote_expression,
     ),
+
+    adjoint_expression: $ => prec(PREC.postfix, seq(
+      $._primary_expression,
+      token.immediate("'"),
+    )),
 
     field_expression: $ => prec(PREC.dot, seq(
       field('value', $._primary_expression),
@@ -874,7 +880,6 @@ module.exports = grammar({
       $._number,
       $._primary_expression,
       $.macrocall_expression,
-      $.adjoint_expression,
       $.unary_expression,
       $.binary_expression,
       $.range_expression,
@@ -889,11 +894,6 @@ module.exports = grammar({
       prec(-1, alias(':', $.operator)),
       prec(-1, alias('begin', $.identifier)),
     ),
-
-    adjoint_expression: $ => prec(PREC.postfix, seq(
-      $._primary_expression,
-      token.immediate("'"),
-    )),
 
     unary_expression: $ => prec.right(PREC.prefix, seq(
       alias($._unary_operator, $.operator),

--- a/grammar.js
+++ b/grammar.js
@@ -181,7 +181,7 @@ module.exports = grammar({
     // Comprehensions with newlines
     [$.matrix_row, $.comprehension_expression],
 
-    [$.juxtaposition_expression, $._literal],
+    [$.juxtaposition_expression, $._number],
     [$.juxtaposition_expression, $._expression], // adjoint
   ],
 
@@ -551,6 +551,7 @@ module.exports = grammar({
       $.curly_expression, // Only valid in macros
       $.parenthesized_expression,
       $.tuple_expression,
+      $._string,
     ),
 
     _array: $ => choice(
@@ -687,8 +688,6 @@ module.exports = grammar({
       $.index_expression,
       $.interpolation_expression,
       $.quote_expression,
-      $.prefixed_command_literal,
-      $.prefixed_string_literal,
     ),
 
     field_expression: $ => prec(PREC.dot, seq(
@@ -698,10 +697,7 @@ module.exports = grammar({
         $.identifier,
         $.interpolation_expression,
         $.quote_expression,
-        $.command_literal,
-        $.string_literal,
-        $.prefixed_command_literal,
-        $.prefixed_string_literal,
+        $._string,
       ),
     )),
 
@@ -823,7 +819,7 @@ module.exports = grammar({
     interpolation_expression: $ => prec.right(PREC.prefix, seq(
       '$',
       choice(
-        $._literal,
+        $._number,
         $._quotable,
       ),
     )),
@@ -831,7 +827,8 @@ module.exports = grammar({
     quote_expression: $ => prec.right(PREC.prefix, seq(
       ':',
       choice(
-        $._literal,
+        $._number,
+        $._string,
         $.identifier,
         $.operator,
         seq($._immediate_brace, $.curly_expression),
@@ -874,7 +871,7 @@ module.exports = grammar({
       // All previous rules are expressions
       $._definition,
       $._statement,
-      $._literal,
+      $._number,
       $._primary_expression,
       $.macrocall_expression,
       $.adjoint_expression,
@@ -1004,9 +1001,6 @@ module.exports = grammar({
         $.typed_expression,
         $.operator,
 
-        $.prefixed_command_literal,
-        $.prefixed_string_literal,
-
         $.binary_expression,
         $.unary_expression,
         $.bare_tuple
@@ -1135,13 +1129,10 @@ module.exports = grammar({
 
     // Literals
 
-    _literal: $ => choice(
+    _number: $ => choice(
       $.boolean_literal,
       $.integer_literal,
       $.float_literal,
-      $.character_literal,
-      $.string_literal,
-      $.command_literal,
     ),
 
     boolean_literal: _ => choice('true', 'false'),
@@ -1187,6 +1178,14 @@ module.exports = grammar({
 
       return choice(leading_period, trailing_period, just_exponent, hex_float);
     },
+
+    _string: $ => choice(
+      $.character_literal,
+      $.string_literal,
+      $.command_literal,
+      $.prefixed_string_literal,
+      $.prefixed_command_literal,
+    ),
 
     escape_sequence: _ => ESCAPE_SEQUENCE,
 

--- a/grammar.js
+++ b/grammar.js
@@ -1,4 +1,5 @@
 const PREC = [
+  'afunc',
   'pair',
   'conditional',
   'arrow',
@@ -30,57 +31,57 @@ PREC.assign = -2;
 PREC.stmt = -3;
 PREC.macro_arg = -4;
 
-const ASSIGN_OPERATORS = `
-  += -= *= /= //= \\= ^= ÷= %= <<= >>= >>>= |= &= ⊻= ≔ ⩴ ≕
-`;
+const OPERATORS = {
+  assignment: `
+    += -= *= /= //= \\= ^= %= <<= >>= >>>= |= &=
+    −= ÷= ⊻= ≔ ⩴ ≕
+  `,
 
-const ARROW_OPERATORS = `
-  ← → ↔ ↚ ↛ ↞ ↠ ↢ ↣ ↦ ↤ ↮ ⇎ ⇍ ⇏ ⇐ ⇒ ⇔ ⇴ ⇶
-  ⇷ ⇸ ⇹ ⇺ ⇻ ⇼ ⇽ ⇾ ⇿ ⟵ ⟶ ⟷ ⟹ ⟺ ⟻ ⟼ ⟽ ⟾
-  ⟿ ⤀ ⤁ ⤂ ⤃ ⤄ ⤅ ⤆ ⤇ ⤌ ⤍ ⤎ ⤏ ⤐ ⤑ ⤔ ⤕ ⤖ ⤗ ⤘
-  ⤝ ⤞ ⤟ ⤠ ⥄ ⥅ ⥆ ⥇ ⥈ ⥊ ⥋ ⥎ ⥐ ⥒ ⥓ ⥖ ⥗ ⥚ ⥛ ⥞ ⥟
-  ⥢ ⥤ ⥦ ⥧ ⥨ ⥩ ⥪ ⥫ ⥬ ⥭ ⥰ ⧴ ⬱ ⬰ ⬲ ⬳ ⬴ ⬵ ⬶ ⬷
-  ⬸ ⬹ ⬺ ⬻ ⬼ ⬽ ⬾ ⬿ ⭀ ⭁ ⭂ ⭃ ⭄ ⭇ ⭈ ⭉ ⭊ ⭋ ⭌ ￩ ￫
-  ⇜ ⇝ ↜ ↝ ↩ ↪ ↫ ↬ ↼ ↽ ⇀ ⇁ ⇄ ⇆ ⇇ ⇉ ⇋ ⇌ ⇚ ⇛ ⇠ ⇢
-`;
+  arrow: `
+    <-- --> <-->
+    ← → ↔ ↚ ↛ ↞ ↠ ↢ ↣ ↦ ↤ ↮ ⇎ ⇍ ⇏ ⇐ ⇒ ⇔ ⇴ ⇶ ⇷ ⇸ ⇹ ⇺ ⇻ ⇼ ⇽ ⇾ ⇿ ⟵ ⟶ ⟷ ⟹ ⟺ ⟻ ⟼ ⟽ ⟾ ⟿
+    ⤀ ⤁ ⤂ ⤃ ⤄ ⤅ ⤆ ⤇ ⤌ ⤍ ⤎ ⤏ ⤐ ⤑ ⤔ ⤕ ⤖ ⤗ ⤘ ⤝ ⤞ ⤟ ⤠ ⥄ ⥅ ⥆ ⥇ ⥈ ⥊ ⥋ ⥎ ⥐ ⥒ ⥓ ⥖ ⥗ ⥚ ⥛ ⥞
+    ⥟ ⥢ ⥤ ⥦ ⥧ ⥨ ⥩ ⥪ ⥫ ⥬ ⥭ ⥰ ⧴ ⬱ ⬰ ⬲ ⬳ ⬴ ⬵ ⬶ ⬷ ⬸ ⬹ ⬺ ⬻ ⬼ ⬽ ⬾ ⬿ ⭀ ⭁ ⭂ ⭃ ⥷ ⭄ ⥺ ⭇ ⭈ ⭉
+    ⭊ ⭋ ⭌ ￩ ￫ ⇜ ⇝ ↜ ↝ ↩ ↪ ↫ ↬ ↼ ↽ ⇀ ⇁ ⇄ ⇆ ⇇ ⇉ ⇋ ⇌ ⇚ ⇛ ⇠ ⇢ ↷ ↶ ↺ ↻
+  `,
 
-const COMPARISON_OPERATORS = `
-  > < >= ≥ <= ≤ == === ≡ != ≠ !== ≢ ∈ ∉ ∋ ∌ ⊆ ⊈ ⊂ ⊄ ⊊ ∝ ∊ ∍ ∥ ∦ ∷ ∺ ∻ ∽ ∾ ≁
-  ≃ ≂ ≄ ≅ ≆ ≇ ≈ ≉ ≊ ≋ ≌ ≍ ≎ ≐ ≑ ≒ ≓ ≖ ≗ ≘ ≙ ≚ ≛ ≜ ≝ ≞ ≟ ≣ ≦ ≧ ≨ ≩ ≪ ≫ ≬ ≭
-  ≮ ≯ ≰ ≱ ≲ ≳ ≴ ≵ ≶ ≷ ≸ ≹ ≺ ≻ ≼ ≽ ≾ ≿ ⊀ ⊁ ⊃ ⊅ ⊇ ⊉ ⊋ ⊏ ⊐ ⊑ ⊒ ⊜ ⊩ ⊬ ⊮ ⊰ ⊱
-  ⊲ ⊳ ⊴ ⊵ ⊶ ⊷ ⋍ ⋐ ⋑ ⋕ ⋖ ⋗ ⋘ ⋙ ⋚ ⋛ ⋜ ⋝ ⋞ ⋟ ⋠ ⋡ ⋢ ⋣ ⋤ ⋥ ⋦ ⋧ ⋨ ⋩ ⋪ ⋫
-  ⋬ ⋭ ⋲ ⋳ ⋴ ⋵ ⋶ ⋷ ⋸ ⋹ ⋺ ⋻ ⋼ ⋽ ⋾ ⋿ ⟈ ⟉ ⟒ ⦷ ⧀ ⧁ ⧡ ⧣ ⧤ ⧥ ⩦ ⩧ ⩪ ⩫ ⩬ ⩭ ⩮ ⩯
-  ⩰ ⩱ ⩲ ⩳ ⩵ ⩶ ⩷ ⩸ ⩹ ⩺ ⩻ ⩼ ⩽ ⩾ ⩿ ⪀ ⪁ ⪂ ⪃ ⪄ ⪅ ⪆ ⪇ ⪈ ⪉ ⪊ ⪋ ⪌ ⪍ ⪎ ⪏ ⪐ ⪑ ⪒ ⪓ ⪔
-  ⪕ ⪖ ⪗ ⪘ ⪙ ⪚ ⪛ ⪜ ⪝ ⪞ ⪟ ⪠ ⪡ ⪢ ⪣ ⪤ ⪥ ⪦ ⪧ ⪨ ⪩ ⪪ ⪫ ⪬ ⪭ ⪮ ⪯ ⪰ ⪱ ⪲ ⪳ ⪴ ⪵ ⪶ ⪷ ⪸
-  ⪹ ⪺ ⪻ ⪼ ⪽ ⪾ ⪿ ⫀ ⫁ ⫂ ⫃ ⫄ ⫅ ⫆ ⫇ ⫈ ⫉ ⫊ ⫋ ⫌ ⫍ ⫎ ⫏ ⫐ ⫑ ⫒ ⫓ ⫔ ⫕ ⫖ ⫗ ⫘ ⫙ ⫷ ⫸
-  ⫹ ⫺ ⊢ ⊣ ⟂
-`;
+  comparison: `
+    > < >= <= == === != !==
+    ≥ ≤ ≡ ≠ ≢ ∈ ∉ ∋ ∌ ⊆ ⊈ ⊂ ⊄ ⊊ ∝ ∊ ∍ ∥ ∦ ∷ ∺ ∻ ∽ ∾ ≁ ≃ ≂ ≄ ≅ ≆ ≇ ≈ ≉ ≊ ≋ ≌ ≍ ≎ ≐
+    ≑ ≒ ≓ ≖ ≗ ≘ ≙ ≚ ≛ ≜ ≝ ≞ ≟ ≣ ≦ ≧ ≨ ≩ ≪ ≫ ≬ ≭ ≮ ≯ ≰ ≱ ≲ ≳ ≴ ≵ ≶ ≷ ≸ ≹ ≺ ≻ ≼ ≽ ≾
+    ≿ ⊀ ⊁ ⊃ ⊅ ⊇ ⊉ ⊋ ⊏ ⊐ ⊑ ⊒ ⊜ ⊩ ⊬ ⊮ ⊰ ⊱ ⊲ ⊳ ⊴ ⊵ ⊶ ⊷ ⋍ ⋐ ⋑ ⋕ ⋖ ⋗ ⋘ ⋙ ⋚ ⋛ ⋜ ⋝ ⋞ ⋟ ⋠
+    ⋡ ⋢ ⋣ ⋤ ⋥ ⋦ ⋧ ⋨ ⋩ ⋪ ⋫ ⋬ ⋭ ⋲ ⋳ ⋴ ⋵ ⋶ ⋷ ⋸ ⋹ ⋺ ⋻ ⋼ ⋽ ⋾ ⋿ ⟈ ⟉ ⟒ ⦷ ⧀ ⧁ ⧡ ⧣ ⧤ ⧥ ⩦ ⩧
+    ⩪ ⩫ ⩬ ⩭ ⩮ ⩯ ⩰ ⩱ ⩲ ⩳ ⩵ ⩶ ⩷ ⩸ ⩹ ⩺ ⩻ ⩼ ⩽ ⩾ ⩿ ⪀ ⪁ ⪂ ⪃ ⪄ ⪅ ⪆ ⪇ ⪈ ⪉ ⪊ ⪋ ⪌ ⪍ ⪎ ⪏ ⪐ ⪑
+    ⪒ ⪓ ⪔ ⪕ ⪖ ⪗ ⪘ ⪙ ⪚ ⪛ ⪜ ⪝ ⪞ ⪟ ⪠ ⪡ ⪢ ⪣ ⪤ ⪥ ⪦ ⪧ ⪨ ⪩ ⪪ ⪫ ⪬ ⪭ ⪮ ⪯ ⪰ ⪱ ⪲ ⪳ ⪴ ⪵ ⪶ ⪷ ⪸
+    ⪹ ⪺ ⪻ ⪼ ⪽ ⪾ ⪿ ⫀ ⫁ ⫂ ⫃ ⫄ ⫅ ⫆ ⫇ ⫈ ⫉ ⫊ ⫋ ⫌ ⫍ ⫎ ⫏ ⫐ ⫑ ⫒ ⫓ ⫔ ⫕ ⫖ ⫗ ⫘ ⫙ ⫷ ⫸ ⫹ ⫺ ⊢ ⊣
+    ⟂ ⫪ ⫫
+  `,
 
-const ELLIPSIS_OPERATORS = '… ⁝ ⋮ ⋱ ⋰ ⋯';
+  ellipsis: '… ⁝ ⋮ ⋱ ⋰ ⋯',
 
-const PLUS_OPERATORS = `
-  + - | ⊕ ⊖ ⊞ ⊟ ++ ∪ ∨ ⊔ ± ∓ ∔ ∸ ≂ ≏ ⊎ ⊻ ⊽ ⋎ ⋓ ⧺ ⧻ ⨈
-  ⨢ ⨣ ⨤ ⨥ ⨦ ⨧ ⨨ ⨩ ⨪ ⨫ ⨬ ⨭ ⨮ ⨹ ⨺ ⩁ ⩂ ⩅ ⩊ ⩌ ⩏ ⩐ ⩒ ⩔ ⩖ ⩗ ⩛ ⩝ ⩡ ⩢ ⩣
-`;
+  plus: `
+    ++ |
+    − ¦ ⊕ ⊖ ⊞ ⊟ ∪ ∨ ⊔ ± ∓ ∔ ∸ ≏ ⊎ ⊻ ⊽ ⋎ ⋓ ⟇ ⧺ ⧻ ⨈ ⨢ ⨣ ⨤ ⨥ ⨦ ⨧ ⨨ ⨩ ⨪ ⨫ ⨬ ⨭ ⨮ ⨹ ⨺ ⩁
+    ⩂ ⩅ ⩊ ⩌ ⩏ ⩐ ⩒ ⩔ ⩖ ⩗ ⩛ ⩝ ⩡ ⩢ ⩣
+  `,
 
-const TIMES_OPERATORS = `
-  * / ÷ % & ⋅ ∘ × \\ ∩ ∧ ⊗ ⊘ ⊙ ⊚ ⊛ ⊠ ⊡ ⊓ ∗ ∙
-  ∤ ⅋ ≀ ⊼ ⋄ ⋆ ⋇ ⋉ ⋊ ⋋ ⋌ ⋏ ⋒ ⟑ ⦸ ⦼ ⦾ ⦿ ⧶ ⧷ ⨇ ⨰
-  ⨱ ⨲ ⨳ ⨴ ⨵ ⨶ ⨷ ⨸ ⨻ ⨼ ⨽ ⩀ ⩃ ⩄ ⩋ ⩍ ⩎ ⩑ ⩓ ⩕ ⩘
-  ⩚ ⩜ ⩞ ⩟ ⩠ ⫛ ⊍ ▷ ⨝ ⟕ ⟖ ⟗
-`;
+  times: `
+    * / % & \\
+    ⌿ ÷ · · ⋅ ∘ × ∩ ∧ ⊗ ⊘ ⊙ ⊚ ⊛ ⊠ ⊡ ⊓ ∗ ∙ ∤ ⅋ ≀ ⊼ ⋄ ⋆ ⋇ ⋉ ⋊ ⋋ ⋌ ⋏ ⋒ ⟑ ⦸ ⦼ ⦾ ⦿ ⧶ ⧷
+    ⨇ ⨰ ⨱ ⨲ ⨳ ⨴ ⨵ ⨶ ⨷ ⨸ ⨻ ⨼ ⨽ ⩀ ⩃ ⩄ ⩋ ⩍ ⩎ ⩑ ⩓ ⩕ ⩘ ⩚ ⩜ ⩞ ⩟ ⩠ ⫛ ⊍ ▷ ⨝ ⟕ ⟖ ⟗ ⨟
+  `,
 
-const BITSHIFT_OPERATORS = '<< >> >>>';
+  bitshift: '<< >> >>>',
 
-const POWER_OPERATORS = `
-  ^ ↑ ↓ ⇵ ⟰ ⟱ ⤈ ⤉ ⤊ ⤋ ⤒ ⤓ ⥉ ⥌ ⥍ ⥏ ⥑ ⥔ ⥕ ⥘ ⥙ ⥜ ⥝ ⥠ ⥡ ⥣ ⥥ ⥮ ⥯ ￪ ￬
-`;
+  power: `
+    ^
+    ↑ ↓ ⇵ ⟰ ⟱ ⤈ ⤉ ⤊ ⤋ ⤒ ⤓ ⥉ ⥌ ⥍ ⥏ ⥑ ⥔ ⥕ ⥘ ⥙ ⥜ ⥝ ⥠ ⥡ ⥣ ⥥ ⥮ ⥯ ￪ ￬
+  `,
 
-const BINARY_AND_UNARY_PLUS_OPERATOR = token(addDots('+ - ± ∓'));
+  unary: '! ¬ √ ∛ ∜',
 
-const LAZY_AND = token(addDots('&&'));
-
-const LAZY_OR = token(addDots('||'));
+  unary_plus: '+ - ± ∓',
+};
 
 const SYNTACTIC_OPERATOR = token(choice('$', '->', '.', '...'));
 
@@ -301,10 +302,10 @@ module.exports = grammar({
       'end'
     ),
 
-    type_clause: $ => seq(
-      choice('<:', '>:'),
+    type_clause: $ => prec.right(PREC.prefix, seq(
+      alias($._type_order_operator, $.operator),
       $._primary_expression
-    ),
+    )),
 
     function_definition: $ => seq(
       'function',
@@ -362,11 +363,11 @@ module.exports = grammar({
       repeat($.where_clause),
     ),
 
-    where_clause: $ => seq(
+    where_clause: $ => prec.left(seq(
       'where',
       $._primary_expression,
       optional($.type_clause),
-    ),
+    )),
 
     macro_definition: $ => seq(
       'macro',
@@ -925,26 +926,25 @@ module.exports = grammar({
           // Syntactic operators in parentheses
           parenthesize(
             alias(
-              token(choice(
+              choice(
                 '::', ':=', '.=', '=',
-                LAZY_AND,
-                LAZY_OR,
                 SYNTACTIC_OPERATOR,
-                addDots(ASSIGN_OPERATORS),
-              )),
+                $._lazy_or_operator,
+                $._lazy_and_operator,
+                $._assignment_operator,
+              ),
               $.operator,
             ),
           ),
         )),
         // Syntactic operators without parentheses
         alias(
-          token.immediate(choice(
-            BINARY_AND_UNARY_PLUS_OPERATOR,
-            LAZY_AND,
-            LAZY_OR,
+          choice(
             SYNTACTIC_OPERATOR,
-            addDots(ASSIGN_OPERATORS),
-          )),
+            $._lazy_or_operator,
+            $._lazy_and_operator,
+            $._assignment_operator,
+          ),
           $.operator,
         ),
         alias(token.immediate(KEYWORDS), $.identifier),
@@ -969,26 +969,21 @@ module.exports = grammar({
       $.where_expression,
     ),
 
-    unary_expression: $ => prec.right(PREC.prefix, seq(
-      alias($._unary_operator, $.operator),
-      $._expression,
-    )),
-
     binary_expression: $ => {
       const table = [
-        [prec.left, PREC.power, $._power_operator],
-        [prec.left, PREC.rational, $._rational_operator],
-        [prec.left, PREC.bitshift, $._bitshift_operator],
-        [prec.left, PREC.times, $._times_operator],
-        [prec.left, PREC.plus, choice(BINARY_AND_UNARY_PLUS_OPERATOR, $._plus_operator)],
-        [prec.left, PREC.colon, $._ellipsis_operator],
+        [prec.right, PREC.pair, $._pair_operator],
         [prec.right, PREC.arrow, $._arrow_operator],
+        [prec.left, PREC.lazy_or, $._lazy_or_operator],
+        [prec.left, PREC.lazy_and, $._lazy_and_operator],
+        [prec.left, PREC.comparison, choice('in', 'isa', $._comparison_operator, $._type_order_operator)],
         [prec.right, PREC.pipe_left, $._pipe_left_operator],
         [prec.left, PREC.pipe_right, $._pipe_right_operator],
-        [prec.left, PREC.comparison, choice('in', 'isa', $._comparison_operator)],
-        [prec.left, PREC.lazy_or, LAZY_OR],
-        [prec.left, PREC.lazy_and, LAZY_AND],
-        [prec.right, PREC.pair, $._pair_operator],
+        [prec.left, PREC.colon, $._ellipsis_operator],
+        [prec.left, PREC.plus, choice($._unary_plus_operator, $._plus_operator)],
+        [prec.left, PREC.times, $._times_operator],
+        [prec.left, PREC.rational, $._rational_operator],
+        [prec.left, PREC.bitshift, $._bitshift_operator],
+        [prec.left, PREC.power, $._power_operator],
       ];
 
       return choice(...table.map(([fn, prec, op]) => fn(prec, seq(
@@ -997,6 +992,15 @@ module.exports = grammar({
         $._expression,
       ))));
     },
+
+    unary_expression: $ => prec.right(PREC.prefix, seq(
+      alias(choice(
+        $._tilde_operator,
+        $._unary_operator,
+        $._unary_plus_operator,
+      ), $.operator),
+      $._expression,
+    )),
 
     range_expression: $ => prec.left(PREC.colon, seq(
       $._expression,
@@ -1026,7 +1030,7 @@ module.exports = grammar({
       choice($._primary_expression)
     )),
 
-    function_expression: $ => prec.right(PREC.arrow, seq(
+    function_expression: $ => prec.right(PREC.afunc, seq(
       choice(
         $.identifier,
         $.parameter_list,
@@ -1050,7 +1054,7 @@ module.exports = grammar({
 
     compound_assignment_expression: $ => prec.right(PREC.assign, seq(
       $._primary_expression,
-      alias($._assign_operator, $.operator),
+      alias(choice($._assignment_operator, $._tilde_operator), $.operator),
       $._expression,
     )),
 
@@ -1085,27 +1089,20 @@ module.exports = grammar({
       const nonIdentifierCharacters = [
         '#',
         '$',
-        '&',
         ',',
         ':',
         ';',
         '@',
+        '~',
         '(', ')',
         '{', '}',
-        ASSIGN_OPERATORS,
-        ARROW_OPERATORS,
-        COMPARISON_OPERATORS,
-        ELLIPSIS_OPERATORS,
-        PLUS_OPERATORS,
-        TIMES_OPERATORS,
-        BITSHIFT_OPERATORS,
-        POWER_OPERATORS
+        ...Object.values(OPERATORS),
       ].join(' ')
         .trim()
-        .replace(/\s+/g, '')
+        .replace(/!/g, '')
         .replace(/-/g, '')
         .replace(/\\/g, '\\\\')
-        .replace(/!/g, '');
+        .replace(/\s+/g, '');
 
       // Some symbols in Sm and So unicode categories that are identifiers
       const validMathSymbols = "°∀-∇∎-∑∫-∳";
@@ -1114,22 +1111,6 @@ module.exports = grammar({
       const rest = `[^"'\`\\s\\.\\-\\[\\]${nonIdentifierCharacters }]*`;
       return new RegExp(start + rest);
     },
-
-    operator: $ => choice(
-      // NOTE: Syntactic operators (&&, +=, etc) cannot be used as identifiers.
-      $._pair_operator,
-      $._arrow_operator,
-      $._comparison_operator,
-      $._pipe_left_operator,
-      $._pipe_right_operator,
-      $._ellipsis_operator,
-      $._plus_operator,
-      $._times_operator,
-      $._rational_operator,
-      $._bitshift_operator,
-      $._power_operator,
-      $._unary_operator,
-    ),
 
     // Literals
 
@@ -1241,31 +1222,62 @@ module.exports = grammar({
       ),
     ),
 
-    _unary_operator: _ => token(addDots('+ - ! ~ ¬ √ ∛ ∜')),
+    operator: $ => choice(
+      // NOTE: Syntactic operators (&&, +=, etc) cannot be used as identifiers.
+      $._pair_operator,
+      $._arrow_operator,
+      $._comparison_operator,
+      $._pipe_left_operator,
+      $._pipe_right_operator,
+      $._ellipsis_operator,
+      $._plus_operator,
+      $._times_operator,
+      $._rational_operator,
+      $._bitshift_operator,
+      $._power_operator,
+      $._tilde_operator,
+      $._type_order_operator,
+      $._unary_operator,
+      $._unary_plus_operator,
+    ),
 
-    _power_operator: _ => token(addDots(POWER_OPERATORS)),
-
-    _bitshift_operator: _ => token(addDots(BITSHIFT_OPERATORS)),
-
-    _rational_operator: _ => token(addDots('//')),
-
-    _times_operator: _ => token(addDots(TIMES_OPERATORS)),
-
-    _plus_operator: _ => token(addDots(PLUS_OPERATORS)),
-
-    _ellipsis_operator: _ => token(choice('..', addDots(ELLIPSIS_OPERATORS))),
-
-    _pipe_left_operator: _ => token(addDots('<|')),
-
-    _pipe_right_operator: _ => token(addDots('|>')),
-
-    _comparison_operator: _ => token(choice('<:', '>:', addDots(COMPARISON_OPERATORS))),
-
-    _arrow_operator: _ => token(choice('<--', '-->', '<-->', addDots(ARROW_OPERATORS))),
+    _assignment_operator: _ => token(choice(':=', '$=', '.=', addDots(OPERATORS.assignment))),
 
     _pair_operator: _ => token(addDots('=>')),
 
-    _assign_operator: _ => token(choice(':=', '~', '$=', '.=', addDots(ASSIGN_OPERATORS))),
+    _arrow_operator: _ => token(addDots(OPERATORS.arrow)),
+
+    _lazy_or_operator: _ => token(addDots('||')),
+
+    _lazy_and_operator: _ => token(addDots('&&')),
+
+    _comparison_operator: _ => token(addDots(OPERATORS.comparison)),
+
+    _pipe_right_operator: _ => token(addDots('|>')),
+
+    _pipe_left_operator: _ => token(addDots('<|')),
+
+    _ellipsis_operator: _ => token(choice('..', addDots(OPERATORS.ellipsis))),
+
+    _plus_operator: _ => token(addDots(OPERATORS.plus)),
+
+    _times_operator: _ => token(addDots(OPERATORS.times)),
+
+    _rational_operator: _ => token(addDots('//')),
+
+    _bitshift_operator: _ => token(addDots(OPERATORS.bitshift)),
+
+    _power_operator: _ => token(addDots(OPERATORS.power)),
+
+
+    _tilde_operator: _ => token(addDots('~')), // unary or assignment
+
+    _type_order_operator: _ => token(addDots('<: >:')), // unary or comparison
+
+    _unary_operator: _ => token(addDots(OPERATORS.unary)),
+
+    _unary_plus_operator: _ => token(addDots(OPERATORS.unary_plus)),
+
 
     _terminator: _ => choice('\n', /;+/),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -29,10 +29,6 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "_declaration"
-                },
-                {
-                  "type": "SYMBOL",
                   "name": "assignment"
                 },
                 {
@@ -60,10 +56,6 @@
                       {
                         "type": "SYMBOL",
                         "name": "_expression"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_declaration"
                       },
                       {
                         "type": "SYMBOL",
@@ -97,6 +89,182 @@
           ]
         }
       ]
+    },
+    "_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_number"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_primary_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_operation"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "macrocall_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "operator"
+        },
+        {
+          "type": "PREC",
+          "value": -1,
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": ":"
+            },
+            "named": true,
+            "value": "operator"
+          }
+        },
+        {
+          "type": "PREC",
+          "value": -1,
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "begin"
+            },
+            "named": true,
+            "value": "identifier"
+          }
+        }
+      ]
+    },
+    "assignment": {
+      "type": "PREC_RIGHT",
+      "value": -2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_quotable"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "field_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "index_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "parametrized_type_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "interpolation_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "quote_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "typed_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "operator"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "binary_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "unary_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "bare_tuple"
+              }
+            ]
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "="
+            },
+            "named": true,
+            "value": "operator"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "assignment"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "bare_tuple"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "bare_tuple": {
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "PREC",
+              "value": -1,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
     },
     "_definition": {
       "type": "CHOICE",
@@ -467,26 +635,26 @@
       ]
     },
     "type_clause": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "<:"
+      "type": "PREC_RIGHT",
+      "value": 25,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_type_order_operator"
             },
-            {
-              "type": "STRING",
-              "value": ">:"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_primary_expression"
-        }
-      ]
+            "named": true,
+            "value": "operator"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_primary_expression"
+          }
+        ]
+      }
     },
     "function_definition": {
       "type": "SEQ",
@@ -583,7 +751,7 @@
     },
     "short_function_definition": {
       "type": "PREC_RIGHT",
-      "value": 10,
+      "value": -2,
       "content": {
         "type": "SEQ",
         "members": [
@@ -764,29 +932,33 @@
       ]
     },
     "where_clause": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "where"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_primary_expression"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "type_clause"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "where"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_primary_expression"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "type_clause"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "macro_definition": {
       "type": "SEQ",
@@ -1262,6 +1434,18 @@
         {
           "type": "SYMBOL",
           "name": "return_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "const_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "global_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "local_statement"
         },
         {
           "type": "SYMBOL",
@@ -1843,7 +2027,7 @@
     },
     "return_statement": {
       "type": "PREC_RIGHT",
-      "value": -2,
+      "value": -3,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1873,6 +2057,120 @@
               },
               {
                 "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "const_statement": {
+      "type": "PREC_RIGHT",
+      "value": -3,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "const"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "assignment"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "typed_expression"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "global_statement": {
+      "type": "PREC_RIGHT",
+      "value": -3,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "global"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "assignment"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "bare_tuple"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "typed_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "function_definition"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "short_function_definition"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "local_statement": {
+      "type": "PREC_RIGHT",
+      "value": -3,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "local"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "assignment"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "bare_tuple"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "typed_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "function_definition"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "short_function_definition"
               }
             ]
           }
@@ -2146,6 +2444,10 @@
         {
           "type": "SYMBOL",
           "name": "tuple_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_string"
         }
       ]
     },
@@ -2641,10 +2943,6 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "_declaration"
-                },
-                {
-                  "type": "SYMBOL",
                   "name": "_expression"
                 },
                 {
@@ -2669,10 +2967,6 @@
                   {
                     "type": "CHOICE",
                     "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_declaration"
-                      },
                       {
                         "type": "SYMBOL",
                         "name": "_expression"
@@ -3005,6 +3299,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "adjoint_expression"
+        },
+        {
+          "type": "SYMBOL",
           "name": "broadcast_call_expression"
         },
         {
@@ -3039,16 +3337,28 @@
         {
           "type": "SYMBOL",
           "name": "quote_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "prefixed_command_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "prefixed_string_literal"
         }
       ]
+    },
+    "adjoint_expression": {
+      "type": "PREC",
+      "value": 26,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_primary_expression"
+          },
+          {
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "STRING",
+              "value": "'"
+            }
+          }
+        ]
+      }
     },
     "field_expression": {
       "type": "PREC",
@@ -3088,19 +3398,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "command_literal"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "string_literal"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "prefixed_command_literal"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "prefixed_string_literal"
+                "name": "_string"
               }
             ]
           }
@@ -3372,17 +3670,13 @@
         "type": "REPEAT1",
         "content": {
           "type": "PREC",
-          "value": -3,
+          "value": -4,
           "content": {
             "type": "CHOICE",
             "members": [
               {
                 "type": "SYMBOL",
                 "name": "_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_declaration"
               },
               {
                 "type": "SYMBOL",
@@ -3846,7 +4140,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_literal"
+                "name": "_number"
               },
               {
                 "type": "SYMBOL",
@@ -3872,7 +4166,11 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_literal"
+                "name": "_number"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_string"
               },
               {
                 "type": "SYMBOL",
@@ -3936,204 +4234,41 @@
                           {
                             "type": "ALIAS",
                             "content": {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "::"
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": ":="
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": ".="
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "="
-                                  },
-                                  {
-                                    "type": "TOKEN",
-                                    "content": {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "CHOICE",
-                                          "members": [
-                                            {
-                                              "type": "STRING",
-                                              "value": "."
-                                            },
-                                            {
-                                              "type": "BLANK"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "CHOICE",
-                                          "members": [
-                                            {
-                                              "type": "STRING",
-                                              "value": "&&"
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "type": "TOKEN",
-                                    "content": {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "CHOICE",
-                                          "members": [
-                                            {
-                                              "type": "STRING",
-                                              "value": "."
-                                            },
-                                            {
-                                              "type": "BLANK"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "CHOICE",
-                                          "members": [
-                                            {
-                                              "type": "STRING",
-                                              "value": "||"
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "type": "TOKEN",
-                                    "content": {
-                                      "type": "CHOICE",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "$"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "->"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "."
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "..."
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "CHOICE",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "."
-                                          },
-                                          {
-                                            "type": "BLANK"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "CHOICE",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "+="
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": "-="
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": "*="
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": "/="
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": "//="
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\="
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": "^="
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": "÷="
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": "%="
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": "<<="
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": ">>="
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": ">>>="
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": "|="
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": "&="
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": "⊻="
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": "≔"
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": "⩴"
-                                          },
-                                          {
-                                            "type": "STRING",
-                                            "value": "≕"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "STRING",
+                                  "value": "::"
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": ":="
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": ".="
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": "="
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "_assignment_operator"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "_lazy_or_operator"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "_lazy_and_operator"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "_syntactic_operator"
+                                }
+                              ]
                             },
                             "named": true,
                             "value": "operator"
@@ -4151,229 +4286,25 @@
               {
                 "type": "ALIAS",
                 "content": {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "TOKEN",
-                        "content": {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "STRING",
-                                  "value": "."
-                                },
-                                {
-                                  "type": "BLANK"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "STRING",
-                                  "value": "+"
-                                },
-                                {
-                                  "type": "STRING",
-                                  "value": "-"
-                                },
-                                {
-                                  "type": "STRING",
-                                  "value": "±"
-                                },
-                                {
-                                  "type": "STRING",
-                                  "value": "∓"
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "type": "TOKEN",
-                        "content": {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "STRING",
-                                  "value": "."
-                                },
-                                {
-                                  "type": "BLANK"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "STRING",
-                                  "value": "&&"
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "type": "TOKEN",
-                        "content": {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "STRING",
-                                  "value": "."
-                                },
-                                {
-                                  "type": "BLANK"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "STRING",
-                                  "value": "||"
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "type": "TOKEN",
-                        "content": {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "$"
-                            },
-                            {
-                              "type": "STRING",
-                              "value": "->"
-                            },
-                            {
-                              "type": "STRING",
-                              "value": "."
-                            },
-                            {
-                              "type": "STRING",
-                              "value": "..."
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": "."
-                              },
-                              {
-                                "type": "BLANK"
-                              }
-                            ]
-                          },
-                          {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": "+="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "-="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "*="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "/="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "//="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "\\="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "^="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "÷="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "%="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "<<="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": ">>="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": ">>>="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "|="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "&="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "⊻="
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "≔"
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "⩴"
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "≕"
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_assignment_operator"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_lazy_or_operator"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_lazy_and_operator"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_syntactic_operator"
+                    }
+                  ]
                 },
                 "named": true,
                 "value": "operator"
@@ -4492,33 +4423,9 @@
         ]
       }
     },
-    "_expression": {
+    "_operation": {
       "type": "CHOICE",
       "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_definition"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_primary_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "macrocall_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "adjoint_expression"
-        },
         {
           "type": "SYMBOL",
           "name": "unary_expression"
@@ -4558,87 +4465,15 @@
         {
           "type": "SYMBOL",
           "name": "where_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "operator"
-        },
-        {
-          "type": "PREC",
-          "value": -1,
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "STRING",
-              "value": ":"
-            },
-            "named": true,
-            "value": "operator"
-          }
-        },
-        {
-          "type": "PREC",
-          "value": -1,
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "STRING",
-              "value": "begin"
-            },
-            "named": true,
-            "value": "identifier"
-          }
         }
       ]
-    },
-    "adjoint_expression": {
-      "type": "PREC",
-      "value": 26,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_primary_expression"
-          },
-          {
-            "type": "IMMEDIATE_TOKEN",
-            "content": {
-              "type": "STRING",
-              "value": "'"
-            }
-          }
-        ]
-      }
-    },
-    "unary_expression": {
-      "type": "PREC_RIGHT",
-      "value": 25,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_unary_operator"
-            },
-            "named": true,
-            "value": "operator"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_expression"
-          }
-        ]
-      }
     },
     "binary_expression": {
       "type": "CHOICE",
       "members": [
         {
-          "type": "PREC_LEFT",
-          "value": 27,
+          "type": "PREC_RIGHT",
+          "value": 11,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4650,183 +4485,7 @@
                 "type": "ALIAS",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_power_operator"
-                },
-                "named": true,
-                "value": "operator"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": 22,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_rational_operator"
-                },
-                "named": true,
-                "value": "operator"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": 23,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_bitshift_operator"
-                },
-                "named": true,
-                "value": "operator"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": 21,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_times_operator"
-                },
-                "named": true,
-                "value": "operator"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": 20,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": "."
-                              },
-                              {
-                                "type": "BLANK"
-                              }
-                            ]
-                          },
-                          {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": "+"
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "-"
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "±"
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "∓"
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_plus_operator"
-                    }
-                  ]
-                },
-                "named": true,
-                "value": "operator"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": 19,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_ellipsis_operator"
+                  "name": "_pair_operator"
                 },
                 "named": true,
                 "value": "operator"
@@ -4853,6 +4512,101 @@
                 "content": {
                   "type": "SYMBOL",
                   "name": "_arrow_operator"
+                },
+                "named": true,
+                "value": "operator"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 14,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_lazy_or_operator"
+                },
+                "named": true,
+                "value": "operator"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 15,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_lazy_and_operator"
+                },
+                "named": true,
+                "value": "operator"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 16,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "in"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "isa"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_comparison_operator"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_type_order_operator"
+                    }
+                  ]
                 },
                 "named": true,
                 "value": "operator"
@@ -4918,7 +4672,33 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 16,
+          "value": 19,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_ellipsis_operator"
+                },
+                "named": true,
+                "value": "operator"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 20,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4932,16 +4712,12 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "STRING",
-                      "value": "in"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "isa"
+                      "type": "SYMBOL",
+                      "name": "_unary_plus_operator"
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "_comparison_operator"
+                      "name": "_plus_operator"
                     }
                   ]
                 },
@@ -4957,7 +4733,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 14,
+          "value": 21,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4968,33 +4744,8 @@
               {
                 "type": "ALIAS",
                 "content": {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "."
-                          },
-                          {
-                            "type": "BLANK"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "||"
-                          }
-                        ]
-                      }
-                    ]
-                  }
+                  "type": "SYMBOL",
+                  "name": "_times_operator"
                 },
                 "named": true,
                 "value": "operator"
@@ -5008,7 +4759,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 15,
+          "value": 22,
           "content": {
             "type": "SEQ",
             "members": [
@@ -5019,33 +4770,8 @@
               {
                 "type": "ALIAS",
                 "content": {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "."
-                          },
-                          {
-                            "type": "BLANK"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "&&"
-                          }
-                        ]
-                      }
-                    ]
-                  }
+                  "type": "SYMBOL",
+                  "name": "_rational_operator"
                 },
                 "named": true,
                 "value": "operator"
@@ -5058,8 +4784,8 @@
           }
         },
         {
-          "type": "PREC_RIGHT",
-          "value": 11,
+          "type": "PREC_LEFT",
+          "value": 23,
           "content": {
             "type": "SEQ",
             "members": [
@@ -5071,7 +4797,33 @@
                 "type": "ALIAS",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_pair_operator"
+                  "name": "_bitshift_operator"
+                },
+                "named": true,
+                "value": "operator"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 27,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_power_operator"
                 },
                 "named": true,
                 "value": "operator"
@@ -5084,6 +4836,41 @@
           }
         }
       ]
+    },
+    "unary_expression": {
+      "type": "PREC_RIGHT",
+      "value": 25,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_tilde_operator"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_unary_operator"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_unary_plus_operator"
+                }
+              ]
+            },
+            "named": true,
+            "value": "operator"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        ]
+      }
     },
     "range_expression": {
       "type": "PREC_LEFT",
@@ -5201,7 +4988,7 @@
     },
     "function_expression": {
       "type": "PREC_RIGHT",
-      "value": 13,
+      "value": 10,
       "content": {
         "type": "SEQ",
         "members": [
@@ -5279,7 +5066,7 @@
     },
     "compound_assignment_expression": {
       "type": "PREC_RIGHT",
-      "value": 10,
+      "value": -2,
       "content": {
         "type": "SEQ",
         "members": [
@@ -5290,8 +5077,17 @@
           {
             "type": "ALIAS",
             "content": {
-              "type": "SYMBOL",
-              "name": "_assign_operator"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_assignment_operator"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_tilde_operator"
+                }
+              ]
             },
             "named": true,
             "value": "operator"
@@ -5324,262 +5120,6 @@
         ]
       }
     },
-    "assignment": {
-      "type": "PREC_RIGHT",
-      "value": 10,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_quotable"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "field_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "index_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "parametrized_type_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "interpolation_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "quote_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "typed_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "operator"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "prefixed_command_literal"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "prefixed_string_literal"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "binary_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "unary_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "bare_tuple"
-              }
-            ]
-          },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "STRING",
-              "value": "="
-            },
-            "named": true,
-            "value": "operator"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "assignment"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "bare_tuple"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "_declaration": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "const_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "local_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "global_declaration"
-        }
-      ]
-    },
-    "const_declaration": {
-      "type": "PREC_RIGHT",
-      "value": -2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "const"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "assignment"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "typed_expression"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "global_declaration": {
-      "type": "PREC_RIGHT",
-      "value": -2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "global"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "assignment"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "bare_tuple"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "typed_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "function_definition"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "short_function_definition"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "local_declaration": {
-      "type": "PREC_RIGHT",
-      "value": -2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "local"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "assignment"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "bare_tuple"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "typed_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "function_definition"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "short_function_definition"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "bare_tuple": {
-      "type": "PREC",
-      "value": -1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_expression"
-          },
-          {
-            "type": "REPEAT1",
-            "content": {
-              "type": "PREC",
-              "value": -1,
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_expression"
-                  }
-                ]
-              }
-            }
-          }
-        ]
-      }
-    },
     "macro_identifier": {
       "type": "SEQ",
       "members": [
@@ -5596,20 +5136,17 @@
             },
             {
               "type": "SYMBOL",
-              "name": "operator"
+              "name": "scoped_identifier"
             },
             {
               "type": "SYMBOL",
-              "name": "scoped_identifier"
+              "name": "operator"
             },
             {
               "type": "ALIAS",
               "content": {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "STRING",
-                  "value": "."
-                }
+                "type": "SYMBOL",
+                "name": "_syntactic_operator"
               },
               "named": true,
               "value": "operator"
@@ -5662,62 +5199,9 @@
     },
     "identifier": {
       "type": "PATTERN",
-      "value": "[_\\p{XID_Start}°∀-∇∎-∑∫-∳\\p{Emoji}&&[^0-9#*]][^\"'`\\s\\.\\-\\[\\]#$&,:;@(){}+==*=/=//=\\\\=^=÷=%=<<=>>=>>>=|=&=⊻=≔⩴≕←→↔↚↛↞↠↢↣↦↤↮⇎⇍⇏⇐⇒⇔⇴⇶⇷⇸⇹⇺⇻⇼⇽⇾⇿⟵⟶⟷⟹⟺⟻⟼⟽⟾⟿⤀⤁⤂⤃⤄⤅⤆⤇⤌⤍⤎⤏⤐⤑⤔⤕⤖⤗⤘⤝⤞⤟⤠⥄⥅⥆⥇⥈⥊⥋⥎⥐⥒⥓⥖⥗⥚⥛⥞⥟⥢⥤⥦⥧⥨⥩⥪⥫⥬⥭⥰⧴⬱⬰⬲⬳⬴⬵⬶⬷⬸⬹⬺⬻⬼⬽⬾⬿⭀⭁⭂⭃⭄⭇⭈⭉⭊⭋⭌￩￫⇜⇝↜↝↩↪↫↬↼↽⇀⇁⇄⇆⇇⇉⇋⇌⇚⇛⇠⇢><>=≥<=≤=====≡=≠==≢∈∉∋∌⊆⊈⊂⊄⊊∝∊∍∥∦∷∺∻∽∾≁≃≂≄≅≆≇≈≉≊≋≌≍≎≐≑≒≓≖≗≘≙≚≛≜≝≞≟≣≦≧≨≩≪≫≬≭≮≯≰≱≲≳≴≵≶≷≸≹≺≻≼≽≾≿⊀⊁⊃⊅⊇⊉⊋⊏⊐⊑⊒⊜⊩⊬⊮⊰⊱⊲⊳⊴⊵⊶⊷⋍⋐⋑⋕⋖⋗⋘⋙⋚⋛⋜⋝⋞⋟⋠⋡⋢⋣⋤⋥⋦⋧⋨⋩⋪⋫⋬⋭⋲⋳⋴⋵⋶⋷⋸⋹⋺⋻⋼⋽⋾⋿⟈⟉⟒⦷⧀⧁⧡⧣⧤⧥⩦⩧⩪⩫⩬⩭⩮⩯⩰⩱⩲⩳⩵⩶⩷⩸⩹⩺⩻⩼⩽⩾⩿⪀⪁⪂⪃⪄⪅⪆⪇⪈⪉⪊⪋⪌⪍⪎⪏⪐⪑⪒⪓⪔⪕⪖⪗⪘⪙⪚⪛⪜⪝⪞⪟⪠⪡⪢⪣⪤⪥⪦⪧⪨⪩⪪⪫⪬⪭⪮⪯⪰⪱⪲⪳⪴⪵⪶⪷⪸⪹⪺⪻⪼⪽⪾⪿⫀⫁⫂⫃⫄⫅⫆⫇⫈⫉⫊⫋⫌⫍⫎⫏⫐⫑⫒⫓⫔⫕⫖⫗⫘⫙⫷⫸⫹⫺⊢⊣⟂…⁝⋮⋱⋰⋯+|⊕⊖⊞⊟++∪∨⊔±∓∔∸≂≏⊎⊻⊽⋎⋓⧺⧻⨈⨢⨣⨤⨥⨦⨧⨨⨩⨪⨫⨬⨭⨮⨹⨺⩁⩂⩅⩊⩌⩏⩐⩒⩔⩖⩗⩛⩝⩡⩢⩣*/÷%&⋅∘×\\\\∩∧⊗⊘⊙⊚⊛⊠⊡⊓∗∙∤⅋≀⊼⋄⋆⋇⋉⋊⋋⋌⋏⋒⟑⦸⦼⦾⦿⧶⧷⨇⨰⨱⨲⨳⨴⨵⨶⨷⨸⨻⨼⨽⩀⩃⩄⩋⩍⩎⩑⩓⩕⩘⩚⩜⩞⩟⩠⫛⊍▷⨝⟕⟖⟗<<>>>>>^↑↓⇵⟰⟱⤈⤉⤊⤋⤒⤓⥉⥌⥍⥏⥑⥔⥕⥘⥙⥜⥝⥠⥡⥣⥥⥮⥯￪￬]*"
+      "value": "[_\\p{XID_Start}°∀-∇∎-∑∫-∳\\p{Emoji}&&[^0-9#*]][^\"'`\\s\\.\\-\\[\\]#$,:;@~(){}+==*=/=//=\\\\=^=%=<<=>>=>>>=|=&=−=÷=⊻=≔⩴≕<><>←→↔↚↛↞↠↢↣↦↤↮⇎⇍⇏⇐⇒⇔⇴⇶⇷⇸⇹⇺⇻⇼⇽⇾⇿⟵⟶⟷⟹⟺⟻⟼⟽⟾⟿⤀⤁⤂⤃⤄⤅⤆⤇⤌⤍⤎⤏⤐⤑⤔⤕⤖⤗⤘⤝⤞⤟⤠⥄⥅⥆⥇⥈⥊⥋⥎⥐⥒⥓⥖⥗⥚⥛⥞⥟⥢⥤⥦⥧⥨⥩⥪⥫⥬⥭⥰⧴⬱⬰⬲⬳⬴⬵⬶⬷⬸⬹⬺⬻⬼⬽⬾⬿⭀⭁⭂⭃⥷⭄⥺⭇⭈⭉⭊⭋⭌￩￫⇜⇝↜↝↩↪↫↬↼↽⇀⇁⇄⇆⇇⇉⇋⇌⇚⇛⇠⇢↷↶↺↻><>=<=========≥≤≡≠≢∈∉∋∌⊆⊈⊂⊄⊊∝∊∍∥∦∷∺∻∽∾≁≃≂≄≅≆≇≈≉≊≋≌≍≎≐≑≒≓≖≗≘≙≚≛≜≝≞≟≣≦≧≨≩≪≫≬≭≮≯≰≱≲≳≴≵≶≷≸≹≺≻≼≽≾≿⊀⊁⊃⊅⊇⊉⊋⊏⊐⊑⊒⊜⊩⊬⊮⊰⊱⊲⊳⊴⊵⊶⊷⋍⋐⋑⋕⋖⋗⋘⋙⋚⋛⋜⋝⋞⋟⋠⋡⋢⋣⋤⋥⋦⋧⋨⋩⋪⋫⋬⋭⋲⋳⋴⋵⋶⋷⋸⋹⋺⋻⋼⋽⋾⋿⟈⟉⟒⦷⧀⧁⧡⧣⧤⧥⩦⩧⩪⩫⩬⩭⩮⩯⩰⩱⩲⩳⩵⩶⩷⩸⩹⩺⩻⩼⩽⩾⩿⪀⪁⪂⪃⪄⪅⪆⪇⪈⪉⪊⪋⪌⪍⪎⪏⪐⪑⪒⪓⪔⪕⪖⪗⪘⪙⪚⪛⪜⪝⪞⪟⪠⪡⪢⪣⪤⪥⪦⪧⪨⪩⪪⪫⪬⪭⪮⪯⪰⪱⪲⪳⪴⪵⪶⪷⪸⪹⪺⪻⪼⪽⪾⪿⫀⫁⫂⫃⫄⫅⫆⫇⫈⫉⫊⫋⫌⫍⫎⫏⫐⫑⫒⫓⫔⫕⫖⫗⫘⫙⫷⫸⫹⫺⊢⊣⟂⫪⫫…⁝⋮⋱⋰⋯++|−¦⊕⊖⊞⊟∪∨⊔±∓∔∸≏⊎⊻⊽⋎⋓⟇⧺⧻⨈⨢⨣⨤⨥⨦⨧⨨⨩⨪⨫⨬⨭⨮⨹⨺⩁⩂⩅⩊⩌⩏⩐⩒⩔⩖⩗⩛⩝⩡⩢⩣*/%&\\\\⌿÷··⋅∘×∩∧⊗⊘⊙⊚⊛⊠⊡⊓∗∙∤⅋≀⊼⋄⋆⋇⋉⋊⋋⋌⋏⋒⟑⦸⦼⦾⦿⧶⧷⨇⨰⨱⨲⨳⨴⨵⨶⨷⨸⨻⨼⨽⩀⩃⩄⩋⩍⩎⩑⩓⩕⩘⩚⩜⩞⩟⩠⫛⊍▷⨝⟕⟖⟗⨟<<>>>>>^↑↓⇵⟰⟱⤈⤉⤊⤋⤒⤓⥉⥌⥍⥏⥑⥔⥕⥘⥙⥜⥝⥠⥡⥣⥥⥮⥯￪￬¬√∛∜+±∓]*"
     },
-    "operator": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_pair_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_arrow_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_comparison_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_pipe_left_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_pipe_right_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_ellipsis_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_plus_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_times_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_rational_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_bitshift_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_power_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_unary_operator"
-        }
-      ]
-    },
-    "_literal": {
+    "_number": {
       "type": "CHOICE",
       "members": [
         {
@@ -5731,18 +5215,6 @@
         {
           "type": "SYMBOL",
           "name": "float_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "character_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "string_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "command_literal"
         }
       ]
     },
@@ -5974,6 +5446,31 @@
               }
             ]
           }
+        }
+      ]
+    },
+    "_string": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "character_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "command_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "prefixed_string_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "prefixed_command_literal"
         }
       ]
     },
@@ -6306,64 +5803,190 @@
         }
       ]
     },
-    "_unary_operator": {
+    "operator": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_pair_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_arrow_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_comparison_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_pipe_left_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_pipe_right_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_ellipsis_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_plus_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_times_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_rational_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_bitshift_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_power_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_tilde_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_type_order_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_unary_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_unary_plus_operator"
+        }
+      ]
+    },
+    "_assignment_operator": {
       "type": "TOKEN",
       "content": {
-        "type": "SEQ",
+        "type": "CHOICE",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "."
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "type": "STRING",
+            "value": ":="
           },
           {
-            "type": "CHOICE",
+            "type": "STRING",
+            "value": "$="
+          },
+          {
+            "type": "STRING",
+            "value": ".="
+          },
+          {
+            "type": "SEQ",
             "members": [
               {
-                "type": "STRING",
-                "value": "+"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "."
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
               },
               {
-                "type": "STRING",
-                "value": "-"
-              },
-              {
-                "type": "STRING",
-                "value": "!"
-              },
-              {
-                "type": "STRING",
-                "value": "~"
-              },
-              {
-                "type": "STRING",
-                "value": "¬"
-              },
-              {
-                "type": "STRING",
-                "value": "√"
-              },
-              {
-                "type": "STRING",
-                "value": "∛"
-              },
-              {
-                "type": "STRING",
-                "value": "∜"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "+="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "-="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "*="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "/="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "//="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "\\="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "^="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "%="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "<<="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ">>="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ">>>="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "|="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "&="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "−="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "÷="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⊻="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "≔"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⩴"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "≕"
+                  }
+                ]
               }
             ]
           }
         ]
       }
     },
-    "_power_operator": {
+    "_pair_operator": {
       "type": "TOKEN",
       "content": {
         "type": "SEQ",
@@ -6385,134 +6008,14 @@
             "members": [
               {
                 "type": "STRING",
-                "value": "^"
-              },
-              {
-                "type": "STRING",
-                "value": "↑"
-              },
-              {
-                "type": "STRING",
-                "value": "↓"
-              },
-              {
-                "type": "STRING",
-                "value": "⇵"
-              },
-              {
-                "type": "STRING",
-                "value": "⟰"
-              },
-              {
-                "type": "STRING",
-                "value": "⟱"
-              },
-              {
-                "type": "STRING",
-                "value": "⤈"
-              },
-              {
-                "type": "STRING",
-                "value": "⤉"
-              },
-              {
-                "type": "STRING",
-                "value": "⤊"
-              },
-              {
-                "type": "STRING",
-                "value": "⤋"
-              },
-              {
-                "type": "STRING",
-                "value": "⤒"
-              },
-              {
-                "type": "STRING",
-                "value": "⤓"
-              },
-              {
-                "type": "STRING",
-                "value": "⥉"
-              },
-              {
-                "type": "STRING",
-                "value": "⥌"
-              },
-              {
-                "type": "STRING",
-                "value": "⥍"
-              },
-              {
-                "type": "STRING",
-                "value": "⥏"
-              },
-              {
-                "type": "STRING",
-                "value": "⥑"
-              },
-              {
-                "type": "STRING",
-                "value": "⥔"
-              },
-              {
-                "type": "STRING",
-                "value": "⥕"
-              },
-              {
-                "type": "STRING",
-                "value": "⥘"
-              },
-              {
-                "type": "STRING",
-                "value": "⥙"
-              },
-              {
-                "type": "STRING",
-                "value": "⥜"
-              },
-              {
-                "type": "STRING",
-                "value": "⥝"
-              },
-              {
-                "type": "STRING",
-                "value": "⥠"
-              },
-              {
-                "type": "STRING",
-                "value": "⥡"
-              },
-              {
-                "type": "STRING",
-                "value": "⥣"
-              },
-              {
-                "type": "STRING",
-                "value": "⥥"
-              },
-              {
-                "type": "STRING",
-                "value": "⥮"
-              },
-              {
-                "type": "STRING",
-                "value": "⥯"
-              },
-              {
-                "type": "STRING",
-                "value": "￪"
-              },
-              {
-                "type": "STRING",
-                "value": "￬"
+                "value": "=>"
               }
             ]
           }
         ]
       }
     },
-    "_bitshift_operator": {
+    "_arrow_operator": {
       "type": "TOKEN",
       "content": {
         "type": "SEQ",
@@ -6534,22 +6037,614 @@
             "members": [
               {
                 "type": "STRING",
-                "value": "<<"
+                "value": "<--"
               },
               {
                 "type": "STRING",
-                "value": ">>"
+                "value": "-->"
               },
               {
                 "type": "STRING",
-                "value": ">>>"
+                "value": "<-->"
+              },
+              {
+                "type": "STRING",
+                "value": "←"
+              },
+              {
+                "type": "STRING",
+                "value": "→"
+              },
+              {
+                "type": "STRING",
+                "value": "↔"
+              },
+              {
+                "type": "STRING",
+                "value": "↚"
+              },
+              {
+                "type": "STRING",
+                "value": "↛"
+              },
+              {
+                "type": "STRING",
+                "value": "↞"
+              },
+              {
+                "type": "STRING",
+                "value": "↠"
+              },
+              {
+                "type": "STRING",
+                "value": "↢"
+              },
+              {
+                "type": "STRING",
+                "value": "↣"
+              },
+              {
+                "type": "STRING",
+                "value": "↦"
+              },
+              {
+                "type": "STRING",
+                "value": "↤"
+              },
+              {
+                "type": "STRING",
+                "value": "↮"
+              },
+              {
+                "type": "STRING",
+                "value": "⇎"
+              },
+              {
+                "type": "STRING",
+                "value": "⇍"
+              },
+              {
+                "type": "STRING",
+                "value": "⇏"
+              },
+              {
+                "type": "STRING",
+                "value": "⇐"
+              },
+              {
+                "type": "STRING",
+                "value": "⇒"
+              },
+              {
+                "type": "STRING",
+                "value": "⇔"
+              },
+              {
+                "type": "STRING",
+                "value": "⇴"
+              },
+              {
+                "type": "STRING",
+                "value": "⇶"
+              },
+              {
+                "type": "STRING",
+                "value": "⇷"
+              },
+              {
+                "type": "STRING",
+                "value": "⇸"
+              },
+              {
+                "type": "STRING",
+                "value": "⇹"
+              },
+              {
+                "type": "STRING",
+                "value": "⇺"
+              },
+              {
+                "type": "STRING",
+                "value": "⇻"
+              },
+              {
+                "type": "STRING",
+                "value": "⇼"
+              },
+              {
+                "type": "STRING",
+                "value": "⇽"
+              },
+              {
+                "type": "STRING",
+                "value": "⇾"
+              },
+              {
+                "type": "STRING",
+                "value": "⇿"
+              },
+              {
+                "type": "STRING",
+                "value": "⟵"
+              },
+              {
+                "type": "STRING",
+                "value": "⟶"
+              },
+              {
+                "type": "STRING",
+                "value": "⟷"
+              },
+              {
+                "type": "STRING",
+                "value": "⟹"
+              },
+              {
+                "type": "STRING",
+                "value": "⟺"
+              },
+              {
+                "type": "STRING",
+                "value": "⟻"
+              },
+              {
+                "type": "STRING",
+                "value": "⟼"
+              },
+              {
+                "type": "STRING",
+                "value": "⟽"
+              },
+              {
+                "type": "STRING",
+                "value": "⟾"
+              },
+              {
+                "type": "STRING",
+                "value": "⟿"
+              },
+              {
+                "type": "STRING",
+                "value": "⤀"
+              },
+              {
+                "type": "STRING",
+                "value": "⤁"
+              },
+              {
+                "type": "STRING",
+                "value": "⤂"
+              },
+              {
+                "type": "STRING",
+                "value": "⤃"
+              },
+              {
+                "type": "STRING",
+                "value": "⤄"
+              },
+              {
+                "type": "STRING",
+                "value": "⤅"
+              },
+              {
+                "type": "STRING",
+                "value": "⤆"
+              },
+              {
+                "type": "STRING",
+                "value": "⤇"
+              },
+              {
+                "type": "STRING",
+                "value": "⤌"
+              },
+              {
+                "type": "STRING",
+                "value": "⤍"
+              },
+              {
+                "type": "STRING",
+                "value": "⤎"
+              },
+              {
+                "type": "STRING",
+                "value": "⤏"
+              },
+              {
+                "type": "STRING",
+                "value": "⤐"
+              },
+              {
+                "type": "STRING",
+                "value": "⤑"
+              },
+              {
+                "type": "STRING",
+                "value": "⤔"
+              },
+              {
+                "type": "STRING",
+                "value": "⤕"
+              },
+              {
+                "type": "STRING",
+                "value": "⤖"
+              },
+              {
+                "type": "STRING",
+                "value": "⤗"
+              },
+              {
+                "type": "STRING",
+                "value": "⤘"
+              },
+              {
+                "type": "STRING",
+                "value": "⤝"
+              },
+              {
+                "type": "STRING",
+                "value": "⤞"
+              },
+              {
+                "type": "STRING",
+                "value": "⤟"
+              },
+              {
+                "type": "STRING",
+                "value": "⤠"
+              },
+              {
+                "type": "STRING",
+                "value": "⥄"
+              },
+              {
+                "type": "STRING",
+                "value": "⥅"
+              },
+              {
+                "type": "STRING",
+                "value": "⥆"
+              },
+              {
+                "type": "STRING",
+                "value": "⥇"
+              },
+              {
+                "type": "STRING",
+                "value": "⥈"
+              },
+              {
+                "type": "STRING",
+                "value": "⥊"
+              },
+              {
+                "type": "STRING",
+                "value": "⥋"
+              },
+              {
+                "type": "STRING",
+                "value": "⥎"
+              },
+              {
+                "type": "STRING",
+                "value": "⥐"
+              },
+              {
+                "type": "STRING",
+                "value": "⥒"
+              },
+              {
+                "type": "STRING",
+                "value": "⥓"
+              },
+              {
+                "type": "STRING",
+                "value": "⥖"
+              },
+              {
+                "type": "STRING",
+                "value": "⥗"
+              },
+              {
+                "type": "STRING",
+                "value": "⥚"
+              },
+              {
+                "type": "STRING",
+                "value": "⥛"
+              },
+              {
+                "type": "STRING",
+                "value": "⥞"
+              },
+              {
+                "type": "STRING",
+                "value": "⥟"
+              },
+              {
+                "type": "STRING",
+                "value": "⥢"
+              },
+              {
+                "type": "STRING",
+                "value": "⥤"
+              },
+              {
+                "type": "STRING",
+                "value": "⥦"
+              },
+              {
+                "type": "STRING",
+                "value": "⥧"
+              },
+              {
+                "type": "STRING",
+                "value": "⥨"
+              },
+              {
+                "type": "STRING",
+                "value": "⥩"
+              },
+              {
+                "type": "STRING",
+                "value": "⥪"
+              },
+              {
+                "type": "STRING",
+                "value": "⥫"
+              },
+              {
+                "type": "STRING",
+                "value": "⥬"
+              },
+              {
+                "type": "STRING",
+                "value": "⥭"
+              },
+              {
+                "type": "STRING",
+                "value": "⥰"
+              },
+              {
+                "type": "STRING",
+                "value": "⧴"
+              },
+              {
+                "type": "STRING",
+                "value": "⬱"
+              },
+              {
+                "type": "STRING",
+                "value": "⬰"
+              },
+              {
+                "type": "STRING",
+                "value": "⬲"
+              },
+              {
+                "type": "STRING",
+                "value": "⬳"
+              },
+              {
+                "type": "STRING",
+                "value": "⬴"
+              },
+              {
+                "type": "STRING",
+                "value": "⬵"
+              },
+              {
+                "type": "STRING",
+                "value": "⬶"
+              },
+              {
+                "type": "STRING",
+                "value": "⬷"
+              },
+              {
+                "type": "STRING",
+                "value": "⬸"
+              },
+              {
+                "type": "STRING",
+                "value": "⬹"
+              },
+              {
+                "type": "STRING",
+                "value": "⬺"
+              },
+              {
+                "type": "STRING",
+                "value": "⬻"
+              },
+              {
+                "type": "STRING",
+                "value": "⬼"
+              },
+              {
+                "type": "STRING",
+                "value": "⬽"
+              },
+              {
+                "type": "STRING",
+                "value": "⬾"
+              },
+              {
+                "type": "STRING",
+                "value": "⬿"
+              },
+              {
+                "type": "STRING",
+                "value": "⭀"
+              },
+              {
+                "type": "STRING",
+                "value": "⭁"
+              },
+              {
+                "type": "STRING",
+                "value": "⭂"
+              },
+              {
+                "type": "STRING",
+                "value": "⭃"
+              },
+              {
+                "type": "STRING",
+                "value": "⥷"
+              },
+              {
+                "type": "STRING",
+                "value": "⭄"
+              },
+              {
+                "type": "STRING",
+                "value": "⥺"
+              },
+              {
+                "type": "STRING",
+                "value": "⭇"
+              },
+              {
+                "type": "STRING",
+                "value": "⭈"
+              },
+              {
+                "type": "STRING",
+                "value": "⭉"
+              },
+              {
+                "type": "STRING",
+                "value": "⭊"
+              },
+              {
+                "type": "STRING",
+                "value": "⭋"
+              },
+              {
+                "type": "STRING",
+                "value": "⭌"
+              },
+              {
+                "type": "STRING",
+                "value": "￩"
+              },
+              {
+                "type": "STRING",
+                "value": "￫"
+              },
+              {
+                "type": "STRING",
+                "value": "⇜"
+              },
+              {
+                "type": "STRING",
+                "value": "⇝"
+              },
+              {
+                "type": "STRING",
+                "value": "↜"
+              },
+              {
+                "type": "STRING",
+                "value": "↝"
+              },
+              {
+                "type": "STRING",
+                "value": "↩"
+              },
+              {
+                "type": "STRING",
+                "value": "↪"
+              },
+              {
+                "type": "STRING",
+                "value": "↫"
+              },
+              {
+                "type": "STRING",
+                "value": "↬"
+              },
+              {
+                "type": "STRING",
+                "value": "↼"
+              },
+              {
+                "type": "STRING",
+                "value": "↽"
+              },
+              {
+                "type": "STRING",
+                "value": "⇀"
+              },
+              {
+                "type": "STRING",
+                "value": "⇁"
+              },
+              {
+                "type": "STRING",
+                "value": "⇄"
+              },
+              {
+                "type": "STRING",
+                "value": "⇆"
+              },
+              {
+                "type": "STRING",
+                "value": "⇇"
+              },
+              {
+                "type": "STRING",
+                "value": "⇉"
+              },
+              {
+                "type": "STRING",
+                "value": "⇋"
+              },
+              {
+                "type": "STRING",
+                "value": "⇌"
+              },
+              {
+                "type": "STRING",
+                "value": "⇚"
+              },
+              {
+                "type": "STRING",
+                "value": "⇛"
+              },
+              {
+                "type": "STRING",
+                "value": "⇠"
+              },
+              {
+                "type": "STRING",
+                "value": "⇢"
+              },
+              {
+                "type": "STRING",
+                "value": "↷"
+              },
+              {
+                "type": "STRING",
+                "value": "↶"
+              },
+              {
+                "type": "STRING",
+                "value": "↺"
+              },
+              {
+                "type": "STRING",
+                "value": "↻"
               }
             ]
           }
         ]
       }
     },
-    "_rational_operator": {
+    "_lazy_or_operator": {
       "type": "TOKEN",
       "content": {
         "type": "SEQ",
@@ -6571,7 +6666,1562 @@
             "members": [
               {
                 "type": "STRING",
-                "value": "//"
+                "value": "||"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_lazy_and_operator": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "&&"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_comparison_operator": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ">"
+              },
+              {
+                "type": "STRING",
+                "value": "<"
+              },
+              {
+                "type": "STRING",
+                "value": ">="
+              },
+              {
+                "type": "STRING",
+                "value": "<="
+              },
+              {
+                "type": "STRING",
+                "value": "=="
+              },
+              {
+                "type": "STRING",
+                "value": "==="
+              },
+              {
+                "type": "STRING",
+                "value": "!="
+              },
+              {
+                "type": "STRING",
+                "value": "!=="
+              },
+              {
+                "type": "STRING",
+                "value": "≥"
+              },
+              {
+                "type": "STRING",
+                "value": "≤"
+              },
+              {
+                "type": "STRING",
+                "value": "≡"
+              },
+              {
+                "type": "STRING",
+                "value": "≠"
+              },
+              {
+                "type": "STRING",
+                "value": "≢"
+              },
+              {
+                "type": "STRING",
+                "value": "∈"
+              },
+              {
+                "type": "STRING",
+                "value": "∉"
+              },
+              {
+                "type": "STRING",
+                "value": "∋"
+              },
+              {
+                "type": "STRING",
+                "value": "∌"
+              },
+              {
+                "type": "STRING",
+                "value": "⊆"
+              },
+              {
+                "type": "STRING",
+                "value": "⊈"
+              },
+              {
+                "type": "STRING",
+                "value": "⊂"
+              },
+              {
+                "type": "STRING",
+                "value": "⊄"
+              },
+              {
+                "type": "STRING",
+                "value": "⊊"
+              },
+              {
+                "type": "STRING",
+                "value": "∝"
+              },
+              {
+                "type": "STRING",
+                "value": "∊"
+              },
+              {
+                "type": "STRING",
+                "value": "∍"
+              },
+              {
+                "type": "STRING",
+                "value": "∥"
+              },
+              {
+                "type": "STRING",
+                "value": "∦"
+              },
+              {
+                "type": "STRING",
+                "value": "∷"
+              },
+              {
+                "type": "STRING",
+                "value": "∺"
+              },
+              {
+                "type": "STRING",
+                "value": "∻"
+              },
+              {
+                "type": "STRING",
+                "value": "∽"
+              },
+              {
+                "type": "STRING",
+                "value": "∾"
+              },
+              {
+                "type": "STRING",
+                "value": "≁"
+              },
+              {
+                "type": "STRING",
+                "value": "≃"
+              },
+              {
+                "type": "STRING",
+                "value": "≂"
+              },
+              {
+                "type": "STRING",
+                "value": "≄"
+              },
+              {
+                "type": "STRING",
+                "value": "≅"
+              },
+              {
+                "type": "STRING",
+                "value": "≆"
+              },
+              {
+                "type": "STRING",
+                "value": "≇"
+              },
+              {
+                "type": "STRING",
+                "value": "≈"
+              },
+              {
+                "type": "STRING",
+                "value": "≉"
+              },
+              {
+                "type": "STRING",
+                "value": "≊"
+              },
+              {
+                "type": "STRING",
+                "value": "≋"
+              },
+              {
+                "type": "STRING",
+                "value": "≌"
+              },
+              {
+                "type": "STRING",
+                "value": "≍"
+              },
+              {
+                "type": "STRING",
+                "value": "≎"
+              },
+              {
+                "type": "STRING",
+                "value": "≐"
+              },
+              {
+                "type": "STRING",
+                "value": "≑"
+              },
+              {
+                "type": "STRING",
+                "value": "≒"
+              },
+              {
+                "type": "STRING",
+                "value": "≓"
+              },
+              {
+                "type": "STRING",
+                "value": "≖"
+              },
+              {
+                "type": "STRING",
+                "value": "≗"
+              },
+              {
+                "type": "STRING",
+                "value": "≘"
+              },
+              {
+                "type": "STRING",
+                "value": "≙"
+              },
+              {
+                "type": "STRING",
+                "value": "≚"
+              },
+              {
+                "type": "STRING",
+                "value": "≛"
+              },
+              {
+                "type": "STRING",
+                "value": "≜"
+              },
+              {
+                "type": "STRING",
+                "value": "≝"
+              },
+              {
+                "type": "STRING",
+                "value": "≞"
+              },
+              {
+                "type": "STRING",
+                "value": "≟"
+              },
+              {
+                "type": "STRING",
+                "value": "≣"
+              },
+              {
+                "type": "STRING",
+                "value": "≦"
+              },
+              {
+                "type": "STRING",
+                "value": "≧"
+              },
+              {
+                "type": "STRING",
+                "value": "≨"
+              },
+              {
+                "type": "STRING",
+                "value": "≩"
+              },
+              {
+                "type": "STRING",
+                "value": "≪"
+              },
+              {
+                "type": "STRING",
+                "value": "≫"
+              },
+              {
+                "type": "STRING",
+                "value": "≬"
+              },
+              {
+                "type": "STRING",
+                "value": "≭"
+              },
+              {
+                "type": "STRING",
+                "value": "≮"
+              },
+              {
+                "type": "STRING",
+                "value": "≯"
+              },
+              {
+                "type": "STRING",
+                "value": "≰"
+              },
+              {
+                "type": "STRING",
+                "value": "≱"
+              },
+              {
+                "type": "STRING",
+                "value": "≲"
+              },
+              {
+                "type": "STRING",
+                "value": "≳"
+              },
+              {
+                "type": "STRING",
+                "value": "≴"
+              },
+              {
+                "type": "STRING",
+                "value": "≵"
+              },
+              {
+                "type": "STRING",
+                "value": "≶"
+              },
+              {
+                "type": "STRING",
+                "value": "≷"
+              },
+              {
+                "type": "STRING",
+                "value": "≸"
+              },
+              {
+                "type": "STRING",
+                "value": "≹"
+              },
+              {
+                "type": "STRING",
+                "value": "≺"
+              },
+              {
+                "type": "STRING",
+                "value": "≻"
+              },
+              {
+                "type": "STRING",
+                "value": "≼"
+              },
+              {
+                "type": "STRING",
+                "value": "≽"
+              },
+              {
+                "type": "STRING",
+                "value": "≾"
+              },
+              {
+                "type": "STRING",
+                "value": "≿"
+              },
+              {
+                "type": "STRING",
+                "value": "⊀"
+              },
+              {
+                "type": "STRING",
+                "value": "⊁"
+              },
+              {
+                "type": "STRING",
+                "value": "⊃"
+              },
+              {
+                "type": "STRING",
+                "value": "⊅"
+              },
+              {
+                "type": "STRING",
+                "value": "⊇"
+              },
+              {
+                "type": "STRING",
+                "value": "⊉"
+              },
+              {
+                "type": "STRING",
+                "value": "⊋"
+              },
+              {
+                "type": "STRING",
+                "value": "⊏"
+              },
+              {
+                "type": "STRING",
+                "value": "⊐"
+              },
+              {
+                "type": "STRING",
+                "value": "⊑"
+              },
+              {
+                "type": "STRING",
+                "value": "⊒"
+              },
+              {
+                "type": "STRING",
+                "value": "⊜"
+              },
+              {
+                "type": "STRING",
+                "value": "⊩"
+              },
+              {
+                "type": "STRING",
+                "value": "⊬"
+              },
+              {
+                "type": "STRING",
+                "value": "⊮"
+              },
+              {
+                "type": "STRING",
+                "value": "⊰"
+              },
+              {
+                "type": "STRING",
+                "value": "⊱"
+              },
+              {
+                "type": "STRING",
+                "value": "⊲"
+              },
+              {
+                "type": "STRING",
+                "value": "⊳"
+              },
+              {
+                "type": "STRING",
+                "value": "⊴"
+              },
+              {
+                "type": "STRING",
+                "value": "⊵"
+              },
+              {
+                "type": "STRING",
+                "value": "⊶"
+              },
+              {
+                "type": "STRING",
+                "value": "⊷"
+              },
+              {
+                "type": "STRING",
+                "value": "⋍"
+              },
+              {
+                "type": "STRING",
+                "value": "⋐"
+              },
+              {
+                "type": "STRING",
+                "value": "⋑"
+              },
+              {
+                "type": "STRING",
+                "value": "⋕"
+              },
+              {
+                "type": "STRING",
+                "value": "⋖"
+              },
+              {
+                "type": "STRING",
+                "value": "⋗"
+              },
+              {
+                "type": "STRING",
+                "value": "⋘"
+              },
+              {
+                "type": "STRING",
+                "value": "⋙"
+              },
+              {
+                "type": "STRING",
+                "value": "⋚"
+              },
+              {
+                "type": "STRING",
+                "value": "⋛"
+              },
+              {
+                "type": "STRING",
+                "value": "⋜"
+              },
+              {
+                "type": "STRING",
+                "value": "⋝"
+              },
+              {
+                "type": "STRING",
+                "value": "⋞"
+              },
+              {
+                "type": "STRING",
+                "value": "⋟"
+              },
+              {
+                "type": "STRING",
+                "value": "⋠"
+              },
+              {
+                "type": "STRING",
+                "value": "⋡"
+              },
+              {
+                "type": "STRING",
+                "value": "⋢"
+              },
+              {
+                "type": "STRING",
+                "value": "⋣"
+              },
+              {
+                "type": "STRING",
+                "value": "⋤"
+              },
+              {
+                "type": "STRING",
+                "value": "⋥"
+              },
+              {
+                "type": "STRING",
+                "value": "⋦"
+              },
+              {
+                "type": "STRING",
+                "value": "⋧"
+              },
+              {
+                "type": "STRING",
+                "value": "⋨"
+              },
+              {
+                "type": "STRING",
+                "value": "⋩"
+              },
+              {
+                "type": "STRING",
+                "value": "⋪"
+              },
+              {
+                "type": "STRING",
+                "value": "⋫"
+              },
+              {
+                "type": "STRING",
+                "value": "⋬"
+              },
+              {
+                "type": "STRING",
+                "value": "⋭"
+              },
+              {
+                "type": "STRING",
+                "value": "⋲"
+              },
+              {
+                "type": "STRING",
+                "value": "⋳"
+              },
+              {
+                "type": "STRING",
+                "value": "⋴"
+              },
+              {
+                "type": "STRING",
+                "value": "⋵"
+              },
+              {
+                "type": "STRING",
+                "value": "⋶"
+              },
+              {
+                "type": "STRING",
+                "value": "⋷"
+              },
+              {
+                "type": "STRING",
+                "value": "⋸"
+              },
+              {
+                "type": "STRING",
+                "value": "⋹"
+              },
+              {
+                "type": "STRING",
+                "value": "⋺"
+              },
+              {
+                "type": "STRING",
+                "value": "⋻"
+              },
+              {
+                "type": "STRING",
+                "value": "⋼"
+              },
+              {
+                "type": "STRING",
+                "value": "⋽"
+              },
+              {
+                "type": "STRING",
+                "value": "⋾"
+              },
+              {
+                "type": "STRING",
+                "value": "⋿"
+              },
+              {
+                "type": "STRING",
+                "value": "⟈"
+              },
+              {
+                "type": "STRING",
+                "value": "⟉"
+              },
+              {
+                "type": "STRING",
+                "value": "⟒"
+              },
+              {
+                "type": "STRING",
+                "value": "⦷"
+              },
+              {
+                "type": "STRING",
+                "value": "⧀"
+              },
+              {
+                "type": "STRING",
+                "value": "⧁"
+              },
+              {
+                "type": "STRING",
+                "value": "⧡"
+              },
+              {
+                "type": "STRING",
+                "value": "⧣"
+              },
+              {
+                "type": "STRING",
+                "value": "⧤"
+              },
+              {
+                "type": "STRING",
+                "value": "⧥"
+              },
+              {
+                "type": "STRING",
+                "value": "⩦"
+              },
+              {
+                "type": "STRING",
+                "value": "⩧"
+              },
+              {
+                "type": "STRING",
+                "value": "⩪"
+              },
+              {
+                "type": "STRING",
+                "value": "⩫"
+              },
+              {
+                "type": "STRING",
+                "value": "⩬"
+              },
+              {
+                "type": "STRING",
+                "value": "⩭"
+              },
+              {
+                "type": "STRING",
+                "value": "⩮"
+              },
+              {
+                "type": "STRING",
+                "value": "⩯"
+              },
+              {
+                "type": "STRING",
+                "value": "⩰"
+              },
+              {
+                "type": "STRING",
+                "value": "⩱"
+              },
+              {
+                "type": "STRING",
+                "value": "⩲"
+              },
+              {
+                "type": "STRING",
+                "value": "⩳"
+              },
+              {
+                "type": "STRING",
+                "value": "⩵"
+              },
+              {
+                "type": "STRING",
+                "value": "⩶"
+              },
+              {
+                "type": "STRING",
+                "value": "⩷"
+              },
+              {
+                "type": "STRING",
+                "value": "⩸"
+              },
+              {
+                "type": "STRING",
+                "value": "⩹"
+              },
+              {
+                "type": "STRING",
+                "value": "⩺"
+              },
+              {
+                "type": "STRING",
+                "value": "⩻"
+              },
+              {
+                "type": "STRING",
+                "value": "⩼"
+              },
+              {
+                "type": "STRING",
+                "value": "⩽"
+              },
+              {
+                "type": "STRING",
+                "value": "⩾"
+              },
+              {
+                "type": "STRING",
+                "value": "⩿"
+              },
+              {
+                "type": "STRING",
+                "value": "⪀"
+              },
+              {
+                "type": "STRING",
+                "value": "⪁"
+              },
+              {
+                "type": "STRING",
+                "value": "⪂"
+              },
+              {
+                "type": "STRING",
+                "value": "⪃"
+              },
+              {
+                "type": "STRING",
+                "value": "⪄"
+              },
+              {
+                "type": "STRING",
+                "value": "⪅"
+              },
+              {
+                "type": "STRING",
+                "value": "⪆"
+              },
+              {
+                "type": "STRING",
+                "value": "⪇"
+              },
+              {
+                "type": "STRING",
+                "value": "⪈"
+              },
+              {
+                "type": "STRING",
+                "value": "⪉"
+              },
+              {
+                "type": "STRING",
+                "value": "⪊"
+              },
+              {
+                "type": "STRING",
+                "value": "⪋"
+              },
+              {
+                "type": "STRING",
+                "value": "⪌"
+              },
+              {
+                "type": "STRING",
+                "value": "⪍"
+              },
+              {
+                "type": "STRING",
+                "value": "⪎"
+              },
+              {
+                "type": "STRING",
+                "value": "⪏"
+              },
+              {
+                "type": "STRING",
+                "value": "⪐"
+              },
+              {
+                "type": "STRING",
+                "value": "⪑"
+              },
+              {
+                "type": "STRING",
+                "value": "⪒"
+              },
+              {
+                "type": "STRING",
+                "value": "⪓"
+              },
+              {
+                "type": "STRING",
+                "value": "⪔"
+              },
+              {
+                "type": "STRING",
+                "value": "⪕"
+              },
+              {
+                "type": "STRING",
+                "value": "⪖"
+              },
+              {
+                "type": "STRING",
+                "value": "⪗"
+              },
+              {
+                "type": "STRING",
+                "value": "⪘"
+              },
+              {
+                "type": "STRING",
+                "value": "⪙"
+              },
+              {
+                "type": "STRING",
+                "value": "⪚"
+              },
+              {
+                "type": "STRING",
+                "value": "⪛"
+              },
+              {
+                "type": "STRING",
+                "value": "⪜"
+              },
+              {
+                "type": "STRING",
+                "value": "⪝"
+              },
+              {
+                "type": "STRING",
+                "value": "⪞"
+              },
+              {
+                "type": "STRING",
+                "value": "⪟"
+              },
+              {
+                "type": "STRING",
+                "value": "⪠"
+              },
+              {
+                "type": "STRING",
+                "value": "⪡"
+              },
+              {
+                "type": "STRING",
+                "value": "⪢"
+              },
+              {
+                "type": "STRING",
+                "value": "⪣"
+              },
+              {
+                "type": "STRING",
+                "value": "⪤"
+              },
+              {
+                "type": "STRING",
+                "value": "⪥"
+              },
+              {
+                "type": "STRING",
+                "value": "⪦"
+              },
+              {
+                "type": "STRING",
+                "value": "⪧"
+              },
+              {
+                "type": "STRING",
+                "value": "⪨"
+              },
+              {
+                "type": "STRING",
+                "value": "⪩"
+              },
+              {
+                "type": "STRING",
+                "value": "⪪"
+              },
+              {
+                "type": "STRING",
+                "value": "⪫"
+              },
+              {
+                "type": "STRING",
+                "value": "⪬"
+              },
+              {
+                "type": "STRING",
+                "value": "⪭"
+              },
+              {
+                "type": "STRING",
+                "value": "⪮"
+              },
+              {
+                "type": "STRING",
+                "value": "⪯"
+              },
+              {
+                "type": "STRING",
+                "value": "⪰"
+              },
+              {
+                "type": "STRING",
+                "value": "⪱"
+              },
+              {
+                "type": "STRING",
+                "value": "⪲"
+              },
+              {
+                "type": "STRING",
+                "value": "⪳"
+              },
+              {
+                "type": "STRING",
+                "value": "⪴"
+              },
+              {
+                "type": "STRING",
+                "value": "⪵"
+              },
+              {
+                "type": "STRING",
+                "value": "⪶"
+              },
+              {
+                "type": "STRING",
+                "value": "⪷"
+              },
+              {
+                "type": "STRING",
+                "value": "⪸"
+              },
+              {
+                "type": "STRING",
+                "value": "⪹"
+              },
+              {
+                "type": "STRING",
+                "value": "⪺"
+              },
+              {
+                "type": "STRING",
+                "value": "⪻"
+              },
+              {
+                "type": "STRING",
+                "value": "⪼"
+              },
+              {
+                "type": "STRING",
+                "value": "⪽"
+              },
+              {
+                "type": "STRING",
+                "value": "⪾"
+              },
+              {
+                "type": "STRING",
+                "value": "⪿"
+              },
+              {
+                "type": "STRING",
+                "value": "⫀"
+              },
+              {
+                "type": "STRING",
+                "value": "⫁"
+              },
+              {
+                "type": "STRING",
+                "value": "⫂"
+              },
+              {
+                "type": "STRING",
+                "value": "⫃"
+              },
+              {
+                "type": "STRING",
+                "value": "⫄"
+              },
+              {
+                "type": "STRING",
+                "value": "⫅"
+              },
+              {
+                "type": "STRING",
+                "value": "⫆"
+              },
+              {
+                "type": "STRING",
+                "value": "⫇"
+              },
+              {
+                "type": "STRING",
+                "value": "⫈"
+              },
+              {
+                "type": "STRING",
+                "value": "⫉"
+              },
+              {
+                "type": "STRING",
+                "value": "⫊"
+              },
+              {
+                "type": "STRING",
+                "value": "⫋"
+              },
+              {
+                "type": "STRING",
+                "value": "⫌"
+              },
+              {
+                "type": "STRING",
+                "value": "⫍"
+              },
+              {
+                "type": "STRING",
+                "value": "⫎"
+              },
+              {
+                "type": "STRING",
+                "value": "⫏"
+              },
+              {
+                "type": "STRING",
+                "value": "⫐"
+              },
+              {
+                "type": "STRING",
+                "value": "⫑"
+              },
+              {
+                "type": "STRING",
+                "value": "⫒"
+              },
+              {
+                "type": "STRING",
+                "value": "⫓"
+              },
+              {
+                "type": "STRING",
+                "value": "⫔"
+              },
+              {
+                "type": "STRING",
+                "value": "⫕"
+              },
+              {
+                "type": "STRING",
+                "value": "⫖"
+              },
+              {
+                "type": "STRING",
+                "value": "⫗"
+              },
+              {
+                "type": "STRING",
+                "value": "⫘"
+              },
+              {
+                "type": "STRING",
+                "value": "⫙"
+              },
+              {
+                "type": "STRING",
+                "value": "⫷"
+              },
+              {
+                "type": "STRING",
+                "value": "⫸"
+              },
+              {
+                "type": "STRING",
+                "value": "⫹"
+              },
+              {
+                "type": "STRING",
+                "value": "⫺"
+              },
+              {
+                "type": "STRING",
+                "value": "⊢"
+              },
+              {
+                "type": "STRING",
+                "value": "⊣"
+              },
+              {
+                "type": "STRING",
+                "value": "⟂"
+              },
+              {
+                "type": "STRING",
+                "value": "⫪"
+              },
+              {
+                "type": "STRING",
+                "value": "⫫"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_pipe_right_operator": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "|>"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_pipe_left_operator": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "<|"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_ellipsis_operator": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "STRING",
+            "value": ".."
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "."
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "…"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⁝"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⋮"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⋱"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⋰"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "⋯"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_plus_operator": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "++"
+              },
+              {
+                "type": "STRING",
+                "value": "|"
+              },
+              {
+                "type": "STRING",
+                "value": "−"
+              },
+              {
+                "type": "STRING",
+                "value": "¦"
+              },
+              {
+                "type": "STRING",
+                "value": "⊕"
+              },
+              {
+                "type": "STRING",
+                "value": "⊖"
+              },
+              {
+                "type": "STRING",
+                "value": "⊞"
+              },
+              {
+                "type": "STRING",
+                "value": "⊟"
+              },
+              {
+                "type": "STRING",
+                "value": "∪"
+              },
+              {
+                "type": "STRING",
+                "value": "∨"
+              },
+              {
+                "type": "STRING",
+                "value": "⊔"
+              },
+              {
+                "type": "STRING",
+                "value": "±"
+              },
+              {
+                "type": "STRING",
+                "value": "∓"
+              },
+              {
+                "type": "STRING",
+                "value": "∔"
+              },
+              {
+                "type": "STRING",
+                "value": "∸"
+              },
+              {
+                "type": "STRING",
+                "value": "≏"
+              },
+              {
+                "type": "STRING",
+                "value": "⊎"
+              },
+              {
+                "type": "STRING",
+                "value": "⊻"
+              },
+              {
+                "type": "STRING",
+                "value": "⊽"
+              },
+              {
+                "type": "STRING",
+                "value": "⋎"
+              },
+              {
+                "type": "STRING",
+                "value": "⋓"
+              },
+              {
+                "type": "STRING",
+                "value": "⟇"
+              },
+              {
+                "type": "STRING",
+                "value": "⧺"
+              },
+              {
+                "type": "STRING",
+                "value": "⧻"
+              },
+              {
+                "type": "STRING",
+                "value": "⨈"
+              },
+              {
+                "type": "STRING",
+                "value": "⨢"
+              },
+              {
+                "type": "STRING",
+                "value": "⨣"
+              },
+              {
+                "type": "STRING",
+                "value": "⨤"
+              },
+              {
+                "type": "STRING",
+                "value": "⨥"
+              },
+              {
+                "type": "STRING",
+                "value": "⨦"
+              },
+              {
+                "type": "STRING",
+                "value": "⨧"
+              },
+              {
+                "type": "STRING",
+                "value": "⨨"
+              },
+              {
+                "type": "STRING",
+                "value": "⨩"
+              },
+              {
+                "type": "STRING",
+                "value": "⨪"
+              },
+              {
+                "type": "STRING",
+                "value": "⨫"
+              },
+              {
+                "type": "STRING",
+                "value": "⨬"
+              },
+              {
+                "type": "STRING",
+                "value": "⨭"
+              },
+              {
+                "type": "STRING",
+                "value": "⨮"
+              },
+              {
+                "type": "STRING",
+                "value": "⨹"
+              },
+              {
+                "type": "STRING",
+                "value": "⨺"
+              },
+              {
+                "type": "STRING",
+                "value": "⩁"
+              },
+              {
+                "type": "STRING",
+                "value": "⩂"
+              },
+              {
+                "type": "STRING",
+                "value": "⩅"
+              },
+              {
+                "type": "STRING",
+                "value": "⩊"
+              },
+              {
+                "type": "STRING",
+                "value": "⩌"
+              },
+              {
+                "type": "STRING",
+                "value": "⩏"
+              },
+              {
+                "type": "STRING",
+                "value": "⩐"
+              },
+              {
+                "type": "STRING",
+                "value": "⩒"
+              },
+              {
+                "type": "STRING",
+                "value": "⩔"
+              },
+              {
+                "type": "STRING",
+                "value": "⩖"
+              },
+              {
+                "type": "STRING",
+                "value": "⩗"
+              },
+              {
+                "type": "STRING",
+                "value": "⩛"
+              },
+              {
+                "type": "STRING",
+                "value": "⩝"
+              },
+              {
+                "type": "STRING",
+                "value": "⩡"
+              },
+              {
+                "type": "STRING",
+                "value": "⩢"
+              },
+              {
+                "type": "STRING",
+                "value": "⩣"
               }
             ]
           }
@@ -6608,15 +8258,31 @@
               },
               {
                 "type": "STRING",
-                "value": "÷"
-              },
-              {
-                "type": "STRING",
                 "value": "%"
               },
               {
                 "type": "STRING",
                 "value": "&"
+              },
+              {
+                "type": "STRING",
+                "value": "\\"
+              },
+              {
+                "type": "STRING",
+                "value": "⌿"
+              },
+              {
+                "type": "STRING",
+                "value": "÷"
+              },
+              {
+                "type": "STRING",
+                "value": "·"
+              },
+              {
+                "type": "STRING",
+                "value": "·"
               },
               {
                 "type": "STRING",
@@ -6629,10 +8295,6 @@
               {
                 "type": "STRING",
                 "value": "×"
-              },
-              {
-                "type": "STRING",
-                "value": "\\"
               },
               {
                 "type": "STRING",
@@ -6901,13 +8563,339 @@
               {
                 "type": "STRING",
                 "value": "⟗"
+              },
+              {
+                "type": "STRING",
+                "value": "⨟"
               }
             ]
           }
         ]
       }
     },
-    "_plus_operator": {
+    "_rational_operator": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "//"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_bitshift_operator": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "<<"
+              },
+              {
+                "type": "STRING",
+                "value": ">>"
+              },
+              {
+                "type": "STRING",
+                "value": ">>>"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_power_operator": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "^"
+              },
+              {
+                "type": "STRING",
+                "value": "↑"
+              },
+              {
+                "type": "STRING",
+                "value": "↓"
+              },
+              {
+                "type": "STRING",
+                "value": "⇵"
+              },
+              {
+                "type": "STRING",
+                "value": "⟰"
+              },
+              {
+                "type": "STRING",
+                "value": "⟱"
+              },
+              {
+                "type": "STRING",
+                "value": "⤈"
+              },
+              {
+                "type": "STRING",
+                "value": "⤉"
+              },
+              {
+                "type": "STRING",
+                "value": "⤊"
+              },
+              {
+                "type": "STRING",
+                "value": "⤋"
+              },
+              {
+                "type": "STRING",
+                "value": "⤒"
+              },
+              {
+                "type": "STRING",
+                "value": "⤓"
+              },
+              {
+                "type": "STRING",
+                "value": "⥉"
+              },
+              {
+                "type": "STRING",
+                "value": "⥌"
+              },
+              {
+                "type": "STRING",
+                "value": "⥍"
+              },
+              {
+                "type": "STRING",
+                "value": "⥏"
+              },
+              {
+                "type": "STRING",
+                "value": "⥑"
+              },
+              {
+                "type": "STRING",
+                "value": "⥔"
+              },
+              {
+                "type": "STRING",
+                "value": "⥕"
+              },
+              {
+                "type": "STRING",
+                "value": "⥘"
+              },
+              {
+                "type": "STRING",
+                "value": "⥙"
+              },
+              {
+                "type": "STRING",
+                "value": "⥜"
+              },
+              {
+                "type": "STRING",
+                "value": "⥝"
+              },
+              {
+                "type": "STRING",
+                "value": "⥠"
+              },
+              {
+                "type": "STRING",
+                "value": "⥡"
+              },
+              {
+                "type": "STRING",
+                "value": "⥣"
+              },
+              {
+                "type": "STRING",
+                "value": "⥥"
+              },
+              {
+                "type": "STRING",
+                "value": "⥮"
+              },
+              {
+                "type": "STRING",
+                "value": "⥯"
+              },
+              {
+                "type": "STRING",
+                "value": "￪"
+              },
+              {
+                "type": "STRING",
+                "value": "￬"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_tilde_operator": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "~"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_type_order_operator": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "<:"
+              },
+              {
+                "type": "STRING",
+                "value": ">:"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_unary_operator": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "!"
+              },
+              {
+                "type": "STRING",
+                "value": "¬"
+              },
+              {
+                "type": "STRING",
+                "value": "√"
+              },
+              {
+                "type": "STRING",
+                "value": "∛"
+              },
+              {
+                "type": "STRING",
+                "value": "∜"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_unary_plus_operator": {
       "type": "TOKEN",
       "content": {
         "type": "SEQ",
@@ -6937,2260 +8925,41 @@
               },
               {
                 "type": "STRING",
-                "value": "|"
-              },
-              {
-                "type": "STRING",
-                "value": "⊕"
-              },
-              {
-                "type": "STRING",
-                "value": "⊖"
-              },
-              {
-                "type": "STRING",
-                "value": "⊞"
-              },
-              {
-                "type": "STRING",
-                "value": "⊟"
-              },
-              {
-                "type": "STRING",
-                "value": "++"
-              },
-              {
-                "type": "STRING",
-                "value": "∪"
-              },
-              {
-                "type": "STRING",
-                "value": "∨"
-              },
-              {
-                "type": "STRING",
-                "value": "⊔"
-              },
-              {
-                "type": "STRING",
                 "value": "±"
               },
               {
                 "type": "STRING",
                 "value": "∓"
-              },
-              {
-                "type": "STRING",
-                "value": "∔"
-              },
-              {
-                "type": "STRING",
-                "value": "∸"
-              },
-              {
-                "type": "STRING",
-                "value": "≂"
-              },
-              {
-                "type": "STRING",
-                "value": "≏"
-              },
-              {
-                "type": "STRING",
-                "value": "⊎"
-              },
-              {
-                "type": "STRING",
-                "value": "⊻"
-              },
-              {
-                "type": "STRING",
-                "value": "⊽"
-              },
-              {
-                "type": "STRING",
-                "value": "⋎"
-              },
-              {
-                "type": "STRING",
-                "value": "⋓"
-              },
-              {
-                "type": "STRING",
-                "value": "⧺"
-              },
-              {
-                "type": "STRING",
-                "value": "⧻"
-              },
-              {
-                "type": "STRING",
-                "value": "⨈"
-              },
-              {
-                "type": "STRING",
-                "value": "⨢"
-              },
-              {
-                "type": "STRING",
-                "value": "⨣"
-              },
-              {
-                "type": "STRING",
-                "value": "⨤"
-              },
-              {
-                "type": "STRING",
-                "value": "⨥"
-              },
-              {
-                "type": "STRING",
-                "value": "⨦"
-              },
-              {
-                "type": "STRING",
-                "value": "⨧"
-              },
-              {
-                "type": "STRING",
-                "value": "⨨"
-              },
-              {
-                "type": "STRING",
-                "value": "⨩"
-              },
-              {
-                "type": "STRING",
-                "value": "⨪"
-              },
-              {
-                "type": "STRING",
-                "value": "⨫"
-              },
-              {
-                "type": "STRING",
-                "value": "⨬"
-              },
-              {
-                "type": "STRING",
-                "value": "⨭"
-              },
-              {
-                "type": "STRING",
-                "value": "⨮"
-              },
-              {
-                "type": "STRING",
-                "value": "⨹"
-              },
-              {
-                "type": "STRING",
-                "value": "⨺"
-              },
-              {
-                "type": "STRING",
-                "value": "⩁"
-              },
-              {
-                "type": "STRING",
-                "value": "⩂"
-              },
-              {
-                "type": "STRING",
-                "value": "⩅"
-              },
-              {
-                "type": "STRING",
-                "value": "⩊"
-              },
-              {
-                "type": "STRING",
-                "value": "⩌"
-              },
-              {
-                "type": "STRING",
-                "value": "⩏"
-              },
-              {
-                "type": "STRING",
-                "value": "⩐"
-              },
-              {
-                "type": "STRING",
-                "value": "⩒"
-              },
-              {
-                "type": "STRING",
-                "value": "⩔"
-              },
-              {
-                "type": "STRING",
-                "value": "⩖"
-              },
-              {
-                "type": "STRING",
-                "value": "⩗"
-              },
-              {
-                "type": "STRING",
-                "value": "⩛"
-              },
-              {
-                "type": "STRING",
-                "value": "⩝"
-              },
-              {
-                "type": "STRING",
-                "value": "⩡"
-              },
-              {
-                "type": "STRING",
-                "value": "⩢"
-              },
-              {
-                "type": "STRING",
-                "value": "⩣"
               }
             ]
           }
         ]
       }
     },
-    "_ellipsis_operator": {
+    "_syntactic_operator": {
       "type": "TOKEN",
       "content": {
         "type": "CHOICE",
         "members": [
           {
             "type": "STRING",
-            "value": ".."
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "."
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "…"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⁝"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋮"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋱"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋰"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋯"
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "_pipe_left_operator": {
-      "type": "TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "."
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "<|"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "_pipe_right_operator": {
-      "type": "TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "."
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "|>"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "_comparison_operator": {
-      "type": "TOKEN",
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "<:"
+            "value": "$"
           },
           {
             "type": "STRING",
-            "value": ">:"
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "."
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ">"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "<"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ">="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≥"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "<="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≤"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "=="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "==="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≡"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "!="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≠"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "!=="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≢"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "∈"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "∉"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "∋"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "∌"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊆"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊈"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊂"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊄"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊊"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "∝"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "∊"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "∍"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "∥"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "∦"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "∷"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "∺"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "∻"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "∽"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "∾"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≁"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≃"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≂"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≄"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≅"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≆"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≇"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≈"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≉"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≊"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≋"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≌"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≍"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≎"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≐"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≑"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≒"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≓"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≖"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≗"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≘"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≙"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≚"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≛"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≜"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≝"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≞"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≟"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≣"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≦"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≧"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≨"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≩"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≪"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≫"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≬"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≭"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≮"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≯"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≰"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≱"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≲"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≳"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≴"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≵"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≶"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≷"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≸"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≹"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≺"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≻"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≼"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≽"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≾"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≿"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊀"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊁"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊃"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊅"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊇"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊉"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊋"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊏"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊐"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊑"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊒"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊜"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊩"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊬"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊮"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊰"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊱"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊲"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊳"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊴"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊵"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊶"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊷"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋍"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋐"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋑"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋕"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋖"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋗"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋘"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋙"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋚"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋛"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋜"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋝"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋞"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋟"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋠"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋡"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋢"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋣"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋤"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋥"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋦"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋧"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋨"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋩"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋪"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋫"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋬"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋭"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋲"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋳"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋴"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋵"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋶"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋷"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋸"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋹"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋺"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋻"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋼"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋽"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋾"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⋿"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟈"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟉"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟒"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⦷"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⧀"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⧁"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⧡"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⧣"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⧤"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⧥"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩦"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩧"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩪"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩫"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩬"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩭"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩮"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩯"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩰"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩱"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩲"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩳"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩵"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩶"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩷"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩸"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩹"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩺"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩻"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩼"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩽"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩾"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩿"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪀"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪁"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪂"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪃"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪄"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪅"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪆"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪇"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪈"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪉"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪊"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪋"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪌"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪍"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪎"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪏"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪐"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪑"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪒"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪓"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪔"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪕"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪖"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪗"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪘"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪙"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪚"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪛"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪜"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪝"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪞"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪟"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪠"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪡"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪢"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪣"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪤"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪥"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪦"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪧"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪨"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪩"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪪"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪫"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪬"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪭"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪮"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪯"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪰"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪱"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪲"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪳"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪴"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪵"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪶"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪷"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪸"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪹"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪺"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪻"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪼"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪽"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪾"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⪿"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫀"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫁"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫂"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫃"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫄"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫅"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫆"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫇"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫈"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫉"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫊"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫋"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫌"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫍"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫎"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫏"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫐"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫑"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫒"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫓"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫔"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫕"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫖"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫗"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫘"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫙"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫷"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫸"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫹"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⫺"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊢"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊣"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟂"
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "_arrow_operator": {
-      "type": "TOKEN",
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "<--"
+            "value": "."
           },
           {
             "type": "STRING",
-            "value": "-->"
+            "value": "..."
           },
           {
             "type": "STRING",
-            "value": "<-->"
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "."
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "←"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "→"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↔"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↚"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↛"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↞"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↠"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↢"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↣"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↦"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↤"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↮"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇎"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇍"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇏"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇐"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇒"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇔"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇴"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇶"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇷"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇸"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇹"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇺"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇻"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇼"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇽"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇾"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇿"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟵"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟶"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟷"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟹"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟺"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟻"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟼"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟽"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟾"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⟿"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤀"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤁"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤂"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤃"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤄"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤅"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤆"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤇"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤌"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤍"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤎"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤏"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤐"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤑"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤔"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤕"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤖"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤗"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤘"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤝"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤞"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤟"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⤠"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥄"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥅"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥆"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥇"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥈"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥊"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥋"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥎"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥐"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥒"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥓"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥖"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥗"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥚"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥛"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥞"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥟"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥢"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥤"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥦"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥧"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥨"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥩"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥪"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥫"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥬"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥭"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⥰"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⧴"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬱"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬰"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬲"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬳"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬴"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬵"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬶"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬷"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬸"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬹"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬺"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬻"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬼"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬽"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬾"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⬿"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭀"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭁"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭂"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭃"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭄"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭇"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭈"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭉"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭊"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭋"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⭌"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "￩"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "￫"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇜"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇝"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↜"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↝"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↩"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↪"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↫"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↬"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↼"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "↽"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇀"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇁"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇄"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇆"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇇"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇉"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇋"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇌"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇚"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇛"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇠"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⇢"
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "_pair_operator": {
-      "type": "TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "."
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "=>"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "_assign_operator": {
-      "type": "TOKEN",
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "STRING",
-            "value": ":="
+            "value": "->"
           },
           {
             "type": "STRING",
-            "value": "~"
-          },
-          {
-            "type": "STRING",
-            "value": "$="
-          },
-          {
-            "type": "STRING",
-            "value": ".="
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "."
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "+="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "-="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "*="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "/="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "//="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "\\="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "^="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "÷="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "%="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "<<="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ">>="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ">>>="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "|="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "&="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⊻="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≔"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "⩴"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "≕"
-                  }
-                ]
-              }
-            ]
+            "value": "?"
           }
         ]
       }
@@ -9316,11 +9085,11 @@
     ],
     [
       "juxtaposition_expression",
-      "_literal"
+      "_number"
     ],
     [
       "juxtaposition_expression",
-      "_expression"
+      "_primary_expression"
     ]
   ],
   "precedences": [],
@@ -9377,7 +9146,8 @@
   "inline": [
     "_terminator",
     "_definition",
-    "_statement"
+    "_statement",
+    "_operation"
   ],
   "supertypes": [
     "_expression",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -196,6 +196,10 @@
         "named": true
       },
       {
+        "type": "const_statement",
+        "named": true
+      },
+      {
         "type": "continue_statement",
         "named": true
       },
@@ -208,6 +212,10 @@
         "named": true
       },
       {
+        "type": "global_statement",
+        "named": true
+      },
+      {
         "type": "if_statement",
         "named": true
       },
@@ -217,6 +225,10 @@
       },
       {
         "type": "let_statement",
+        "named": true
+      },
+      {
+        "type": "local_statement",
         "named": true
       },
       {
@@ -280,11 +292,23 @@
       "required": true,
       "types": [
         {
+          "type": "adjoint_expression",
+          "named": true
+        },
+        {
           "type": "broadcast_call_expression",
           "named": true
         },
         {
           "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "command_literal",
           "named": true
         },
         {
@@ -337,6 +361,10 @@
         },
         {
           "type": "quote_expression",
+          "named": true
+        },
+        {
+          "type": "string_literal",
           "named": true
         },
         {
@@ -448,6 +476,10 @@
       "required": true,
       "types": [
         {
+          "type": "adjoint_expression",
+          "named": true
+        },
+        {
           "type": "argument_list",
           "named": true
         },
@@ -457,6 +489,14 @@
         },
         {
           "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "command_literal",
           "named": true
         },
         {
@@ -516,6 +556,10 @@
           "named": true
         },
         {
+          "type": "string_literal",
+          "named": true
+        },
+        {
           "type": "tuple_expression",
           "named": true
         },
@@ -535,6 +579,10 @@
       "required": true,
       "types": [
         {
+          "type": "adjoint_expression",
+          "named": true
+        },
+        {
           "type": "argument_list",
           "named": true
         },
@@ -544,6 +592,14 @@
         },
         {
           "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "command_literal",
           "named": true
         },
         {
@@ -607,6 +663,10 @@
           "named": true
         },
         {
+          "type": "string_literal",
+          "named": true
+        },
+        {
           "type": "tuple_expression",
           "named": true
         },
@@ -635,18 +695,6 @@
         },
         {
           "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
           "named": true
         },
         {
@@ -711,18 +759,6 @@
           "named": true
         },
         {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
-          "named": true
-        },
-        {
           "type": "short_function_definition",
           "named": true
         }
@@ -757,7 +793,7 @@
     }
   },
   {
-    "type": "const_declaration",
+    "type": "const_statement",
     "named": true,
     "fields": {},
     "children": {
@@ -823,18 +859,6 @@
           "named": true
         },
         {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
-          "named": true
-        },
-        {
           "type": "parameter_list",
           "named": true
         },
@@ -863,18 +887,6 @@
         },
         {
           "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
           "named": true
         },
         {
@@ -913,18 +925,6 @@
         },
         {
           "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
           "named": true
         },
         {
@@ -970,11 +970,23 @@
         "required": true,
         "types": [
           {
+            "type": "adjoint_expression",
+            "named": true
+          },
+          {
             "type": "broadcast_call_expression",
             "named": true
           },
           {
             "type": "call_expression",
+            "named": true
+          },
+          {
+            "type": "character_literal",
+            "named": true
+          },
+          {
+            "type": "command_literal",
             "named": true
           },
           {
@@ -1030,6 +1042,10 @@
             "named": true
           },
           {
+            "type": "string_literal",
+            "named": true
+          },
+          {
             "type": "tuple_expression",
             "named": true
           },
@@ -1044,6 +1060,10 @@
       "multiple": false,
       "required": true,
       "types": [
+        {
+          "type": "character_literal",
+          "named": true
+        },
         {
           "type": "command_literal",
           "named": true
@@ -1093,18 +1113,6 @@
         },
         {
           "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
           "named": true
         },
         {
@@ -1174,19 +1182,7 @@
           "named": true
         },
         {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
           "type": "for_binding",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
           "named": true
         },
         {
@@ -1249,11 +1245,23 @@
         "required": false,
         "types": [
           {
+            "type": "adjoint_expression",
+            "named": true
+          },
+          {
             "type": "broadcast_call_expression",
             "named": true
           },
           {
             "type": "call_expression",
+            "named": true
+          },
+          {
+            "type": "character_literal",
+            "named": true
+          },
+          {
+            "type": "command_literal",
             "named": true
           },
           {
@@ -1309,6 +1317,10 @@
             "named": true
           },
           {
+            "type": "string_literal",
+            "named": true
+          },
+          {
             "type": "tuple_expression",
             "named": true
           },
@@ -1333,18 +1345,6 @@
         },
         {
           "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
           "named": true
         },
         {
@@ -1416,11 +1416,23 @@
         "required": true,
         "types": [
           {
+            "type": "adjoint_expression",
+            "named": true
+          },
+          {
             "type": "broadcast_call_expression",
             "named": true
           },
           {
             "type": "call_expression",
+            "named": true
+          },
+          {
+            "type": "character_literal",
+            "named": true
+          },
+          {
+            "type": "command_literal",
             "named": true
           },
           {
@@ -1476,6 +1488,10 @@
             "named": true
           },
           {
+            "type": "string_literal",
+            "named": true
+          },
+          {
             "type": "tuple_expression",
             "named": true
           },
@@ -1498,7 +1514,7 @@
     }
   },
   {
-    "type": "global_declaration",
+    "type": "global_statement",
     "named": true,
     "fields": {},
     "children": {
@@ -1590,18 +1606,6 @@
         },
         {
           "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
           "named": true
         },
         {
@@ -1698,11 +1702,23 @@
       "required": true,
       "types": [
         {
+          "type": "adjoint_expression",
+          "named": true
+        },
+        {
           "type": "broadcast_call_expression",
           "named": true
         },
         {
           "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "command_literal",
           "named": true
         },
         {
@@ -1755,6 +1771,10 @@
         },
         {
           "type": "quote_expression",
+          "named": true
+        },
+        {
+          "type": "string_literal",
           "named": true
         },
         {
@@ -1822,6 +1842,14 @@
           "named": true
         },
         {
+          "type": "prefixed_command_literal",
+          "named": true
+        },
+        {
+          "type": "prefixed_string_literal",
+          "named": true
+        },
+        {
           "type": "string_literal",
           "named": true
         },
@@ -1854,6 +1882,14 @@
         },
         {
           "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "command_literal",
           "named": true
         },
         {
@@ -1914,6 +1950,10 @@
         },
         {
           "type": "quote_expression",
+          "named": true
+        },
+        {
+          "type": "string_literal",
           "named": true
         },
         {
@@ -2002,19 +2042,7 @@
           "named": true
         },
         {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
           "type": "let_binding",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
           "named": true
         },
         {
@@ -2025,7 +2053,7 @@
     }
   },
   {
-    "type": "local_declaration",
+    "type": "local_statement",
     "named": true,
     "fields": {},
     "children": {
@@ -2077,18 +2105,6 @@
         },
         {
           "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
           "named": true
         },
         {
@@ -2148,18 +2164,6 @@
           "named": true
         },
         {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
-          "named": true
-        },
-        {
           "type": "short_function_definition",
           "named": true
         }
@@ -2198,6 +2202,10 @@
       "required": true,
       "types": [
         {
+          "type": "adjoint_expression",
+          "named": true
+        },
+        {
           "type": "argument_list",
           "named": true
         },
@@ -2207,6 +2215,14 @@
         },
         {
           "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "command_literal",
           "named": true
         },
         {
@@ -2271,6 +2287,10 @@
         },
         {
           "type": "quote_expression",
+          "named": true
+        },
+        {
+          "type": "string_literal",
           "named": true
         },
         {
@@ -2351,18 +2371,6 @@
         },
         {
           "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
           "named": true
         },
         {
@@ -2490,11 +2498,23 @@
       "required": true,
       "types": [
         {
+          "type": "adjoint_expression",
+          "named": true
+        },
+        {
           "type": "broadcast_call_expression",
           "named": true
         },
         {
           "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "command_literal",
           "named": true
         },
         {
@@ -2550,6 +2570,10 @@
           "named": true
         },
         {
+          "type": "string_literal",
+          "named": true
+        },
+        {
           "type": "tuple_expression",
           "named": true
         },
@@ -2577,23 +2601,11 @@
           "named": true
         },
         {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
           "type": "for_clause",
           "named": true
         },
         {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
           "type": "if_clause",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
           "named": true
         },
         {
@@ -2766,6 +2778,14 @@
           "named": true
         },
         {
+          "type": "prefixed_command_literal",
+          "named": true
+        },
+        {
+          "type": "prefixed_string_literal",
+          "named": true
+        },
+        {
           "type": "string_literal",
           "named": true
         },
@@ -2798,18 +2818,6 @@
         },
         {
           "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
           "named": true
         },
         {
@@ -2995,11 +3003,23 @@
         "required": false,
         "types": [
           {
+            "type": "adjoint_expression",
+            "named": true
+          },
+          {
             "type": "broadcast_call_expression",
             "named": true
           },
           {
             "type": "call_expression",
+            "named": true
+          },
+          {
+            "type": "character_literal",
+            "named": true
+          },
+          {
+            "type": "command_literal",
             "named": true
           },
           {
@@ -3052,6 +3072,10 @@
           },
           {
             "type": "quote_expression",
+            "named": true
+          },
+          {
+            "type": "string_literal",
             "named": true
           },
           {
@@ -3129,18 +3153,6 @@
         },
         {
           "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
           "named": true
         },
         {
@@ -3239,18 +3251,6 @@
           "named": true
         },
         {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
-          "named": true
-        },
-        {
           "type": "short_function_definition",
           "named": true
         },
@@ -3309,19 +3309,7 @@
           "named": true
         },
         {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
           "type": "finally_clause",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
           "named": true
         },
         {
@@ -3363,15 +3351,27 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "adjoint_expression",
+          "named": true
+        },
         {
           "type": "broadcast_call_expression",
           "named": true
         },
         {
           "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "command_literal",
           "named": true
         },
         {
@@ -3407,6 +3407,10 @@
           "named": true
         },
         {
+          "type": "operator",
+          "named": true
+        },
+        {
           "type": "parametrized_type_expression",
           "named": true
         },
@@ -3424,6 +3428,10 @@
         },
         {
           "type": "quote_expression",
+          "named": true
+        },
+        {
+          "type": "string_literal",
           "named": true
         },
         {
@@ -3502,11 +3510,23 @@
         "required": false,
         "types": [
           {
+            "type": "adjoint_expression",
+            "named": true
+          },
+          {
             "type": "broadcast_call_expression",
             "named": true
           },
           {
             "type": "call_expression",
+            "named": true
+          },
+          {
+            "type": "character_literal",
+            "named": true
+          },
+          {
+            "type": "command_literal",
             "named": true
           },
           {
@@ -3559,6 +3579,10 @@
           },
           {
             "type": "quote_expression",
+            "named": true
+          },
+          {
+            "type": "string_literal",
             "named": true
           },
           {
@@ -3630,11 +3654,23 @@
       "required": true,
       "types": [
         {
+          "type": "adjoint_expression",
+          "named": true
+        },
+        {
           "type": "broadcast_call_expression",
           "named": true
         },
         {
           "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "command_literal",
           "named": true
         },
         {
@@ -3687,6 +3723,10 @@
         },
         {
           "type": "quote_expression",
+          "named": true
+        },
+        {
+          "type": "string_literal",
           "named": true
         },
         {
@@ -3751,18 +3791,6 @@
           "named": true
         },
         {
-          "type": "const_declaration",
-          "named": true
-        },
-        {
-          "type": "global_declaration",
-          "named": true
-        },
-        {
-          "type": "local_declaration",
-          "named": true
-        },
-        {
           "type": "short_function_definition",
           "named": true
         }
@@ -3818,15 +3846,7 @@
     "named": false
   },
   {
-    "type": "<:",
-    "named": false
-  },
-  {
     "type": "=",
-    "named": false
-  },
-  {
-    "type": ">:",
     "named": false
   },
   {

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -41,7 +41,7 @@ abstract type T{S} <: U end
 
   (primitive_definition
     (identifier)
-    (type_clause (identifier))
+    (type_clause (operator) (identifier))
     (integer_literal))
 
   (primitive_definition
@@ -55,13 +55,13 @@ abstract type T{S} <: U end
 
   (abstract_definition
     (identifier)
-    (type_clause (identifier)))
+    (type_clause (operator) (identifier)))
 
   (abstract_definition
     (identifier)
     (type_parameter_list
       (identifier))
-    (type_clause (identifier))))
+    (type_clause (operator) (identifier))))
 
 
 ==============================
@@ -120,14 +120,14 @@ end
     (identifier)
     (type_parameter_list
       (binary_expression (identifier) (operator) (identifier)))
-    (type_clause (identifier))
+    (type_clause (operator) (identifier))
     (typed_expression (identifier) (identifier))
     (typed_expression (identifier) (identifier)))
 
   ;; Parametric fields
   (struct_definition
     (identifier)
-    (type_clause (identifier))
+    (type_clause (operator) (identifier))
     (typed_expression
       (identifier)
       (parametrized_type_expression
@@ -519,6 +519,7 @@ Base.show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m,
                     (where_clause
                       (identifier)
                       (type_clause
+                        (operator)
                         (identifier)))))
     (call_expression (identifier) (argument_list (identifier))))
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -422,6 +422,32 @@ end
 
 
 ==============================
+adjoint expressions
+==============================
+
+[u, v]'
+A'[i]
+(x, y)'
+f'(x)
+:a'
+
+
+---
+(source_file
+  (adjoint_expression
+    (vector_expression (identifier) (identifier)))
+  (index_expression
+    (adjoint_expression (identifier))
+    (vector_expression (identifier)))
+  (adjoint_expression
+    (tuple_expression (identifier) (identifier)))
+  (call_expression
+    (adjoint_expression (identifier))
+    (argument_list (identifier)))
+  (adjoint_expression
+    (quote_expression (identifier))))
+
+==============================
 juxtaposition expressions
 ==============================
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -86,6 +86,7 @@ index expressions
 
 a[1, 2, 3]
 a[1, :]
+"foo"[1]
 
 ---
 (source_file
@@ -99,7 +100,10 @@ a[1, :]
     (identifier)
     (vector_expression
       (integer_literal)
-      (operator))))
+      (operator)))
+  (index_expression
+    (string_literal)
+    (vector_expression (integer_literal))))
 
 
 ==============================

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -124,7 +124,7 @@ $(usertype){T}
     (curly_expression (identifier)))
   (parametrized_type_expression
     (identifier)
-    (curly_expression (type_clause (identifier))))
+    (curly_expression (type_clause (operator) (identifier))))
   (parametrized_type_expression
     (interpolation_expression (parenthesized_expression (identifier)))
     (curly_expression (identifier)))

--- a/test/corpus/operators.txt
+++ b/test/corpus/operators.txt
@@ -189,7 +189,6 @@ x ≥ 0 ≥ z
 unary operators
 ==============================
 
-[a, b]'
 -A'
 +a
 -b
@@ -199,7 +198,6 @@ unary operators
 
 ---
 (source_file
-  (adjoint_expression (vector_expression (identifier) (identifier)))
   (unary_expression (operator) (adjoint_expression (identifier)))
   (unary_expression (operator) (identifier))
   (unary_expression (operator) (identifier))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -307,26 +307,36 @@ import LinearAlgebra as la
 
 
 ===============================
-const declarations
+const statements
 ===============================
 
 const x = 5
 const y, z = 1, 2
 
+(0, const x, y = 1, 2)
+
 ---
 
 (source_file
-  (const_declaration
+  (const_statement
     (assignment (identifier) (operator) (integer_literal)))
-  (const_declaration
+  (const_statement
     (assignment
     (bare_tuple (identifier) (identifier))
     (operator)
-    (bare_tuple (integer_literal) (integer_literal)))))
+    (bare_tuple (integer_literal) (integer_literal))))
+  ; const statements inside tuples
+  (tuple_expression
+    (integer_literal)
+    (const_statement
+      (assignment
+        (bare_tuple (identifier) (identifier))
+        (operator)
+        (bare_tuple (integer_literal) (integer_literal))))))
 
 
 ===============================
-local declarations
+local statements
 ===============================
 
 local x
@@ -337,22 +347,22 @@ local function bar() 4 end
 ---
 
 (source_file
-  (local_declaration (identifier))
-  (local_declaration
+  (local_statement (identifier))
+  (local_statement
     (assignment
     (bare_tuple (identifier) (identifier))
     (operator)
     (bare_tuple (integer_literal) (integer_literal))))
-  (local_declaration
+  (local_statement
     (short_function_definition
       (identifier) (parameter_list) (integer_literal)))
-  (local_declaration
+  (local_statement
     (function_definition
       (identifier) (parameter_list) (integer_literal))))
 
 
 ===============================
-global declarations
+global statements
 ===============================
 
 global X
@@ -363,15 +373,15 @@ global function bar() 4 end
 ---
 
 (source_file
-  (global_declaration (identifier))
-  (global_declaration
+  (global_statement (identifier))
+  (global_statement
     (assignment
     (bare_tuple (identifier) (identifier))
     (operator)
     (bare_tuple (integer_literal) (integer_literal))))
-  (global_declaration
+  (global_statement
     (short_function_definition
       (identifier) (parameter_list) (integer_literal)))
-  (global_declaration
+  (global_statement
     (function_definition
       (identifier) (parameter_list) (integer_literal))))


### PR DESCRIPTION
- Replace `_literal` with two new rules:
  - `_string`, for chars, strings, commands, and prefixed variants.
  - `_number` for the other literals (integers, floats and booleans).
- Make `adjoint_expression` a primary expression. It satisfies all the requirements. You can call, index, parametrize and field access adjoints.
- Add `_operation` rule. This is just an intermediate" rule to keep things tidy, like `_definition` and `_statement`. Now `_expression` serves as a "table of contents" for the grammar.
- Fix precedences and restore const/local/global as statements.
- Add CONTRIBUTING.md Closes #105 


### Operators

- Add new operators from flisp parser.
- Add rules for mixed unary/binary operators.
- Add `_syntactic_operator`.
- Fix precedence for arrow `function_expression` (to be lower than `pair`).
- Organize operators:
  - Place strings inside a single `OPERATORS` object.
  - List ASCII operators first.
  - Sort operators from lowest to highest precedence.