### PR TITLE
Update Info on Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ Julia grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter).
 
 ### References
 
-- [The Julia Parser](https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm)
+- [The Julia Parser: JuliaSyntax.jl](https://github.com/JuliaLang/JuliaSyntax.jl)
 - [Julia ASTs documentation](https://docs.julialang.org/en/v1/devdocs/ast/)
-- [JuliaSyntax.jl](https://julialang.github.io/JuliaSyntax.jl/dev/)
 
 [ci]: https://img.shields.io/github/actions/workflow/status/tree-sitter/tree-sitter-julia/ci.yml?logo=github&label=CI
 [discord]: https://img.shields.io/discord/1063097320771698699?logo=discord&label=discord


### PR DESCRIPTION
The old parser is not used anymore, and a historical relic.  (Aside from the LTS version)

This updates the README to reflect that. 
It also provides a more insightful link to the new parser.