### PR TITLE
Breaking: Refactor signatures and other stuff

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -162,7 +162,7 @@ module.exports = grammar({
     // Comprehensions with newlines
     [$.matrix_row, $.comprehension_expression],
 
-    [$.juxtaposition_expression, $._number],
+    [$.juxtaposition_expression, $._expression],
     [$.juxtaposition_expression, $._primary_expression], // adjoint
   ],
 
@@ -193,7 +193,8 @@ module.exports = grammar({
     _expression: $ => choice(
       $._definition,
       $._statement,
-      $._number,
+      $.integer_literal,
+      $.float_literal,
       $._primary_expression,
       $._operation,
       $.compound_assignment_expression,
@@ -648,6 +649,7 @@ module.exports = grammar({
     // Primary expressions can be called, indexed, accessed, and type parametrized.
     _primary_expression: $ => choice(
       $.identifier,
+      $.boolean_literal,
       $.curly_expression, // Only valid in macros
       $.parenthesized_expression,
       $.tuple_expression,
@@ -772,7 +774,8 @@ module.exports = grammar({
     interpolation_expression: $ => prec.right(PREC.prefix, seq(
       '$',
       choice(
-        $._number,
+        $.integer_literal,
+        $.float_literal,
         $.identifier,
         $.curly_expression,
         $.parenthesized_expression,
@@ -785,7 +788,8 @@ module.exports = grammar({
     quote_expression: $ => prec.right(PREC.prefix, seq(
       ':',
       choice(
-        $._number,
+        $.integer_literal,
+        $.float_literal,
         $._string,
         $.identifier,
         $.operator,
@@ -986,12 +990,6 @@ module.exports = grammar({
     identifier: $ => $._word_identifier,
 
     // Literals
-
-    _number: $ => choice(
-      $.boolean_literal,
-      $.integer_literal,
-      $.float_literal,
-    ),
 
     boolean_literal: _ => choice('true', 'false'),
 

--- a/grammar.js
+++ b/grammar.js
@@ -26,7 +26,7 @@ const PREC = [
 }, {});
 
 PREC.array = -1;
-PREC.tuple = -1; // Bare tuples
+PREC.tuple = -1; // open_tuple
 PREC.assign = -2;
 PREC.stmt = -3;
 PREC.macro_arg = -4;
@@ -177,7 +177,7 @@ module.exports = grammar({
       sep1($._terminator, choice(
         $._expression,
         $.assignment,
-        $.bare_tuple,
+        $.open_tuple,
       )),
       optional($._terminator)
     ),
@@ -186,15 +186,15 @@ module.exports = grammar({
     assignment: $ => prec.right(PREC.assign, seq(
       choice(
         $._primary_expression,
+        $.open_tuple,
         $._operation,
         $.operator,
-        $.bare_tuple
       ),
       alias('=', $.operator),
       choice(
         $._expression,
         $.assignment,
-        $.bare_tuple
+        $.open_tuple,
       )
     )),
 
@@ -212,7 +212,7 @@ module.exports = grammar({
       )
     )),
 
-    bare_tuple: $ => prec(PREC.tuple, seq(
+    open_tuple: $ => prec(PREC.tuple, seq(
       $._expression,
       repeat1(prec(PREC.tuple, seq(',', $._expression)))
     )),
@@ -435,7 +435,7 @@ module.exports = grammar({
       optional(choice(
         $._expression,
         $.assignment,
-        $.bare_tuple,
+        $.open_tuple,
       ))
     )),
 
@@ -447,18 +447,18 @@ module.exports = grammar({
     global_statement: $ => prec.right(PREC.stmt, seq(
       'global',
       choice(
-        $.assignment,
-        $.bare_tuple,
         $._expression,
+        $.assignment,
+        $.open_tuple,
       ),
     )),
 
     local_statement: $ => prec.right(PREC.stmt, seq(
       'local',
       choice(
-        $.assignment,
-        $.bare_tuple,
         $._expression,
+        $.assignment,
+        $.open_tuple,
       ),
     )),
 
@@ -718,7 +718,7 @@ module.exports = grammar({
     macro_argument_list: $ => prec.left(repeat1(prec(PREC.macro_arg, choice(
       $._expression,
       $.assignment,
-      $.bare_tuple,
+      $.open_tuple,
     )))),
 
     argument_list: $ => parenthesize(

--- a/grammar.js
+++ b/grammar.js
@@ -464,7 +464,7 @@ module.exports = grammar({
 
     import_alias: $ => seq($._importable, 'as', $.identifier),
 
-    relative_qualifier: $ => seq(
+    import_path: $ => seq(
       token(repeat1('.')),
       choice(
         $.identifier,
@@ -483,7 +483,7 @@ module.exports = grammar({
     _importable: $ => choice(
       $._exportable,
       $.scoped_identifier,
-      $.relative_qualifier,
+      $.import_path,
     ),
 
     _import_list: $ => prec.right(sep1(',', choice(

--- a/grammar.js
+++ b/grammar.js
@@ -197,7 +197,11 @@ module.exports = grammar({
       $._number,
       $._primary_expression,
       $._operation,
+      $.compound_assignment_expression,
       $.macrocall_expression,
+      $.function_expression,
+      $.juxtaposition_expression,
+      $.ternary_expression,
       $.operator,
       prec(-1, alias(':', $.operator)),
       prec(-1, alias('begin', $.identifier)),
@@ -207,11 +211,8 @@ module.exports = grammar({
     assignment: $ => prec.right(PREC.assign, seq(
       choice(
         $._primary_expression,
-        $.typed_expression,
+        $._operation,
         $.operator,
-        $.binary_expression,
-        $.unary_expression,
-        $.where_expression,
         $.bare_tuple
       ),
       alias('=', $.operator),
@@ -226,11 +227,8 @@ module.exports = grammar({
     _closed_assignment: $ => prec.right(PREC.assign, seq(
       choice(
         $._primary_expression,
-        $.typed_expression,
+        $._operation,
         $.operator,
-        $.binary_expression,
-        $.unary_expression,
-        $.where_expression,
       ),
       alias('=', $.operator),
       choice(
@@ -312,7 +310,7 @@ module.exports = grammar({
       'end'
     ),
 
-    signature: $ => choice(
+    signature: $ => prec.right(choice(
       $.identifier, // zero-method definition
       seq(
         choice(
@@ -322,7 +320,7 @@ module.exports = grammar({
         field('return_type', optional($.unary_typed_expression)),
         optional($.where_clause),
       ),
-    ),
+    )),
 
     // TODO: Remove
     where_clause: $ => seq('where', $._expression),
@@ -748,7 +746,6 @@ module.exports = grammar({
       optional(';'),
       sep(choice(',', ';'), choice(
         $._expression,
-        $.unary_typed_expression,
         alias($._closed_assignment, $.named_argument),
         seq($._expression, $._comprehension_clause),
       )),
@@ -830,18 +827,12 @@ module.exports = grammar({
     // Operations
 
     _operation: $ => choice(
-      // Use regular operators
       $.unary_expression,
       $.binary_expression,
       $.range_expression,
-      // Use syntactic operators
       $.splat_expression,
-      $.ternary_expression,
       $.typed_expression,
-      $.function_expression,
-      // Other stuff
-      $.juxtaposition_expression,
-      $.compound_assignment_expression,
+      $.unary_typed_expression,
       $.where_expression,
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -150,12 +150,11 @@ module.exports = grammar({
   ],
 
   conflicts: $ => [
-    [$.named_field, $._quotable],
+    [$.named_field, $._primary_expression],
 
     [$.argument_list, $.tuple_expression],
     [$.argument_list, $.parenthesized_expression],
 
-    [$.for_binding, $._quotable],
     [$.for_binding, $._primary_expression],
     [$.for_binding, $._expression],
 
@@ -526,17 +525,6 @@ module.exports = grammar({
       ),
     ),
 
-
-    // Quotables are expressions that can be quoted without additional parentheses.
-    _quotable: $ => choice(
-      $._array,
-      $.identifier,
-      $.curly_expression, // Only valid in macros
-      $.parenthesized_expression,
-      $.tuple_expression,
-      $._string,
-    ),
-
     _array: $ => choice(
       $.comprehension_expression,
       $.matrix_expression,
@@ -659,7 +647,12 @@ module.exports = grammar({
 
     // Primary expressions can be called, indexed, accessed, and type parametrized.
     _primary_expression: $ => choice(
-      $._quotable,
+      $.identifier,
+      $.curly_expression, // Only valid in macros
+      $.parenthesized_expression,
+      $.tuple_expression,
+      $._array,
+      $._string,
       $.adjoint_expression,
       $.broadcast_call_expression,
       $.call_expression,
@@ -780,7 +773,12 @@ module.exports = grammar({
       '$',
       choice(
         $._number,
-        $._quotable,
+        $.identifier,
+        $.curly_expression,
+        $.parenthesized_expression,
+        $.tuple_expression,
+        $._array,
+        $._string,
       ),
     )),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -33,11 +33,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "bare_tuple"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "short_function_definition"
+                  "name": "open_tuple"
                 }
               ]
             },
@@ -63,11 +59,7 @@
                       },
                       {
                         "type": "SYMBOL",
-                        "name": "bare_tuple"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "short_function_definition"
+                        "name": "open_tuple"
                       }
                     ]
                   }
@@ -90,65 +82,6 @@
         }
       ]
     },
-    "_expression": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_definition"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_number"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_primary_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_operation"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "macrocall_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "operator"
-        },
-        {
-          "type": "PREC",
-          "value": -1,
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "STRING",
-              "value": ":"
-            },
-            "named": true,
-            "value": "operator"
-          }
-        },
-        {
-          "type": "PREC",
-          "value": -1,
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "STRING",
-              "value": "begin"
-            },
-            "named": true,
-            "value": "identifier"
-          }
-        }
-      ]
-    },
     "assignment": {
       "type": "PREC_RIGHT",
       "value": -2,
@@ -160,47 +93,19 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_quotable"
+                "name": "_primary_expression"
               },
               {
                 "type": "SYMBOL",
-                "name": "field_expression"
+                "name": "open_tuple"
               },
               {
                 "type": "SYMBOL",
-                "name": "index_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "parametrized_type_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "interpolation_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "quote_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "typed_expression"
+                "name": "_operation"
               },
               {
                 "type": "SYMBOL",
                 "name": "operator"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "binary_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "unary_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "bare_tuple"
               }
             ]
           },
@@ -226,14 +131,67 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "bare_tuple"
+                "name": "open_tuple"
               }
             ]
           }
         ]
       }
     },
-    "bare_tuple": {
+    "_closed_assignment": {
+      "type": "PREC_RIGHT",
+      "value": -2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_primary_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_operation"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "operator"
+              }
+            ]
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "="
+            },
+            "named": true,
+            "value": "operator"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_closed_assignment"
+                },
+                "named": true,
+                "value": "assignment"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "open_tuple": {
       "type": "PREC",
       "value": -1,
       "content": {
@@ -265,6 +223,85 @@
           }
         ]
       }
+    },
+    "_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_primary_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_operation"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "compound_assignment_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "macrocall_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "juxtaposition_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ternary_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "integer_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "float_literal"
+        },
+        {
+          "type": "PREC",
+          "value": -1,
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": ":"
+            },
+            "named": true,
+            "value": "operator"
+          }
+        },
+        {
+          "type": "PREC",
+          "value": -1,
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "begin"
+            },
+            "named": true,
+            "value": "identifier"
+          }
+        }
+      ]
     },
     "_definition": {
       "type": "CHOICE",
@@ -636,360 +673,8 @@
           "value": "function"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_function_signature"
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "FIELD",
-                          "name": "parameters",
-                          "content": {
-                            "type": "SYMBOL",
-                            "name": "parameter_list"
-                          }
-                        },
-                        {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "SEQ",
-                              "members": [
-                                {
-                                  "type": "STRING",
-                                  "value": "::"
-                                },
-                                {
-                                  "type": "FIELD",
-                                  "name": "return_type",
-                                  "content": {
-                                    "type": "SYMBOL",
-                                    "name": "_primary_expression"
-                                  }
-                                }
-                              ]
-                            },
-                            {
-                              "type": "BLANK"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "SYMBOL",
-                              "name": "where_clause"
-                            },
-                            {
-                              "type": "BLANK"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_terminator"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_block"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "FIELD",
-              "name": "name",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "operator"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "end"
-        }
-      ]
-    },
-    "short_function_definition": {
-      "type": "PREC_RIGHT",
-      "value": -2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_function_signature"
-          },
-          {
-            "type": "STRING",
-            "value": "="
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "assignment"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "bare_tuple"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "_function_signature": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "operator"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "field_expression"
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "("
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "identifier"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "operator"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ")"
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "("
-                  },
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "typed_parameter"
-                    },
-                    "named": true,
-                    "value": "function_object"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ")"
-                  }
-                ]
-              },
-              {
-                "type": "SYMBOL",
-                "name": "interpolation_expression"
-              }
-            ]
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_immediate_brace"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "curly_expression"
-                  },
-                  "named": true,
-                  "value": "type_parameter_list"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
           "type": "SYMBOL",
-          "name": "_immediate_paren"
-        },
-        {
-          "type": "FIELD",
-          "name": "parameters",
-          "content": {
-            "type": "SYMBOL",
-            "name": "parameter_list"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "::"
-                },
-                {
-                  "type": "FIELD",
-                  "name": "return_type",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_primary_expression"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "where_clause"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
-    },
-    "where_clause": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "where"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
-        }
-      ]
-    },
-    "macro_definition": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "macro"
-        },
-        {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "operator"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "interpolation_expression"
-              }
-            ]
-          }
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_immediate_paren"
-        },
-        {
-          "type": "FIELD",
-          "name": "parameters",
-          "content": {
-            "type": "SYMBOL",
-            "name": "parameter_list"
-          }
+          "name": "signature"
         },
         {
           "type": "CHOICE",
@@ -1021,365 +706,116 @@
         }
       ]
     },
-    "parameter_list": {
+    "macro_definition": {
       "type": "SEQ",
       "members": [
         {
           "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "identifier"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "slurp_parameter"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "optional_parameter"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "typed_parameter"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "tuple_expression"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "interpolation_expression"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "_closed_macrocall_expression"
-                      },
-                      "named": true,
-                      "value": "macrocall_expression"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "call_expression"
-                    }
-                  ]
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "identifier"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "slurp_parameter"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "optional_parameter"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "typed_parameter"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "tuple_expression"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation_expression"
-                          },
-                          {
-                            "type": "ALIAS",
-                            "content": {
-                              "type": "SYMBOL",
-                              "name": "_closed_macrocall_expression"
-                            },
-                            "named": true,
-                            "value": "macrocall_expression"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "call_expression"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "keyword_parameters"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": ")"
-        }
-      ]
-    },
-    "keyword_parameters": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": ";"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "slurp_parameter"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "optional_parameter"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "typed_parameter"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "interpolation_expression"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_closed_macrocall_expression"
-                  },
-                  "named": true,
-                  "value": "macrocall_expression"
-                }
-              ]
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "identifier"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "slurp_parameter"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "optional_parameter"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "typed_parameter"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation_expression"
-                      },
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "SYMBOL",
-                          "name": "_closed_macrocall_expression"
-                        },
-                        "named": true,
-                        "value": "macrocall_expression"
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
-    },
-    "optional_parameter": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "typed_parameter"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "tuple_expression"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "="
+          "value": "macro"
         },
         {
           "type": "SYMBOL",
-          "name": "_expression"
-        }
-      ]
-    },
-    "slurp_parameter": {
-      "type": "SEQ",
-      "members": [
+          "name": "signature"
+        },
         {
           "type": "CHOICE",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_terminator"
             },
             {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
               "type": "SYMBOL",
-              "name": "typed_parameter"
+              "name": "_block"
+            },
+            {
+              "type": "BLANK"
             }
           ]
         },
         {
           "type": "STRING",
-          "value": "..."
+          "value": "end"
         }
       ]
     },
-    "typed_parameter": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "parameter",
-              "content": {
+    "signature": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
                 "type": "CHOICE",
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "identifier"
+                    "name": "call_expression"
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "tuple_expression"
-                  },
+                    "name": "argument_list"
+                  }
+                ]
+              },
+              {
+                "type": "FIELD",
+                "name": "return_type",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "unary_typed_expression"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "interpolation_expression"
+                    "name": "where_clause"
+                  },
+                  {
+                    "type": "BLANK"
                   }
                 ]
               }
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
+            ]
+          }
+        ]
+      }
+    },
+    "where_clause": {
+      "type": "SEQ",
+      "members": [
         {
           "type": "STRING",
-          "value": "::"
+          "value": "where"
         },
         {
-          "type": "FIELD",
-          "name": "type",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_primary_expression"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "where_clause"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_expression"
         }
       ]
     },
@@ -1546,7 +982,7 @@
                       "type": "ALIAS",
                       "content": {
                         "type": "SYMBOL",
-                        "name": "named_field"
+                        "name": "_closed_assignment"
                       },
                       "named": true,
                       "value": "let_binding"
@@ -1573,7 +1009,7 @@
                             "type": "ALIAS",
                             "content": {
                               "type": "SYMBOL",
-                              "name": "named_field"
+                              "name": "_closed_assignment"
                             },
                             "named": true,
                             "value": "let_binding"
@@ -2077,7 +1513,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "bare_tuple"
+                    "name": "open_tuple"
                   }
                 ]
               },
@@ -2100,21 +1536,8 @@
             "value": "const"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "assignment"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "typed_expression"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "assignment"
           }
         ]
       }
@@ -2134,27 +1557,15 @@
             "members": [
               {
                 "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "SYMBOL",
                 "name": "assignment"
               },
               {
                 "type": "SYMBOL",
-                "name": "bare_tuple"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "typed_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "function_definition"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "short_function_definition"
+                "name": "open_tuple"
               }
             ]
           }
@@ -2176,32 +1587,65 @@
             "members": [
               {
                 "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "SYMBOL",
                 "name": "assignment"
               },
               {
                 "type": "SYMBOL",
-                "name": "bare_tuple"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "typed_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "function_definition"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "short_function_definition"
+                "name": "open_tuple"
               }
             ]
           }
         ]
       }
+    },
+    "import_alias": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_importable"
+        },
+        {
+          "type": "STRING",
+          "value": "as"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        }
+      ]
+    },
+    "import_path": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "REPEAT1",
+            "content": {
+              "type": "STRING",
+              "value": "."
+            }
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "scoped_identifier"
+            }
+          ]
+        }
+      ]
     },
     "_exportable": {
       "type": "CHOICE",
@@ -2250,72 +1694,6 @@
         }
       ]
     },
-    "export_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "export"
-        },
-        {
-          "type": "PREC_RIGHT",
-          "value": 0,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_exportable"
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ","
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_exportable"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      ]
-    },
-    "relative_qualifier": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "TOKEN",
-          "content": {
-            "type": "REPEAT1",
-            "content": {
-              "type": "STRING",
-              "value": "."
-            }
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "scoped_identifier"
-            }
-          ]
-        }
-      ]
-    },
     "_importable": {
       "type": "CHOICE",
       "members": [
@@ -2329,24 +1707,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "relative_qualifier"
-        }
-      ]
-    },
-    "import_alias": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_importable"
-        },
-        {
-          "type": "STRING",
-          "value": "as"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "name": "import_path"
         }
       ]
     },
@@ -2417,6 +1778,44 @@
         }
       ]
     },
+    "export_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "export"
+        },
+        {
+          "type": "PREC_RIGHT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_exportable"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_exportable"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
     "import_statement": {
       "type": "SEQ",
       "members": [
@@ -2448,16 +1847,16 @@
         }
       ]
     },
-    "_quotable": {
+    "_primary_expression": {
       "type": "CHOICE",
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_array"
+          "name": "identifier"
         },
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "boolean_literal"
         },
         {
           "type": "SYMBOL",
@@ -2473,7 +1872,52 @@
         },
         {
           "type": "SYMBOL",
+          "name": "_array"
+        },
+        {
+          "type": "SYMBOL",
           "name": "_string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "adjoint_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "broadcast_call_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "call_expression"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_closed_macrocall_expression"
+          },
+          "named": true,
+          "value": "macrocall_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "parametrized_type_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "field_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "index_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "interpolation_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "quote_expression"
         }
       ]
     },
@@ -2512,8 +1956,13 @@
                 "name": "_expression"
               },
               {
-                "type": "SYMBOL",
-                "name": "assignment"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_closed_assignment"
+                },
+                "named": true,
+                "value": "assignment"
               }
             ]
           },
@@ -2684,51 +2133,55 @@
       }
     },
     "for_binding": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "tuple_expression"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "typed_parameter"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "interpolation_expression"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "in"
-            },
-            {
-              "type": "STRING",
-              "value": "="
-            },
-            {
-              "type": "STRING",
-              "value": "∈"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
-        }
-      ]
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "tuple_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "typed_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "interpolation_expression"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "in"
+              },
+              {
+                "type": "STRING",
+                "value": "="
+              },
+              {
+                "type": "STRING",
+                "value": "∈"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        ]
+      }
     },
     "matrix_expression": {
       "type": "PREC",
@@ -2859,7 +2312,7 @@
               "type": "ALIAS",
               "content": {
                 "type": "SYMBOL",
-                "name": "named_field"
+                "name": "_closed_assignment"
               },
               "named": true,
               "value": "assignment"
@@ -2892,7 +2345,7 @@
                       "type": "ALIAS",
                       "content": {
                         "type": "SYMBOL",
-                        "name": "named_field"
+                        "name": "_closed_assignment"
                       },
                       "named": true,
                       "value": "assignment"
@@ -2919,7 +2372,7 @@
                             "type": "ALIAS",
                             "content": {
                               "type": "SYMBOL",
-                              "name": "named_field"
+                              "name": "_closed_assignment"
                             },
                             "named": true,
                             "value": "assignment"
@@ -2972,12 +2425,13 @@
                   "name": "_expression"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "assignment"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "short_function_definition"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_closed_assignment"
+                  },
+                  "named": true,
+                  "value": "assignment"
                 }
               ]
             },
@@ -2998,12 +2452,13 @@
                         "name": "_expression"
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "assignment"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "short_function_definition"
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_closed_assignment"
+                        },
+                        "named": true,
+                        "value": "assignment"
                       }
                     ]
                   }
@@ -3246,7 +2701,7 @@
                       "type": "ALIAS",
                       "content": {
                         "type": "SYMBOL",
-                        "name": "named_field"
+                        "name": "_closed_assignment"
                       },
                       "named": true,
                       "value": "assignment"
@@ -3273,7 +2728,7 @@
                             "type": "ALIAS",
                             "content": {
                               "type": "SYMBOL",
-                              "name": "named_field"
+                              "name": "_closed_assignment"
                             },
                             "named": true,
                             "value": "assignment"
@@ -3305,56 +2760,6 @@
         {
           "type": "STRING",
           "value": "}"
-        }
-      ]
-    },
-    "_primary_expression": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_quotable"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "adjoint_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "broadcast_call_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "call_expression"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_closed_macrocall_expression"
-          },
-          "named": true,
-          "value": "macrocall_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "parametrized_type_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "field_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "index_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "interpolation_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "quote_expression"
         }
       ]
     },
@@ -3702,11 +3107,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "bare_tuple"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "short_function_definition"
+                "name": "open_tuple"
               }
             ]
           }
@@ -3749,7 +3150,7 @@
                       "type": "ALIAS",
                       "content": {
                         "type": "SYMBOL",
-                        "name": "named_field"
+                        "name": "_closed_assignment"
                       },
                       "named": true,
                       "value": "named_argument"
@@ -3798,7 +3199,7 @@
                             "type": "ALIAS",
                             "content": {
                               "type": "SYMBOL",
-                              "name": "named_field"
+                              "name": "_closed_assignment"
                             },
                             "named": true,
                             "value": "named_argument"
@@ -3860,7 +3261,7 @@
             "name": "_do_parameter_list"
           },
           "named": true,
-          "value": "parameter_list"
+          "value": "argument_list"
         },
         {
           "type": "CHOICE",
@@ -3898,45 +3299,19 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "slurp_parameter"
+                      "name": "splat_expression"
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "typed_parameter"
+                      "name": "typed_expression"
                     },
                     {
                       "type": "SYMBOL",
                       "name": "tuple_expression"
                     },
                     {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "("
-                        },
-                        {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "SYMBOL",
-                              "name": "identifier"
-                            },
-                            {
-                              "type": "SYMBOL",
-                              "name": "slurp_parameter"
-                            },
-                            {
-                              "type": "SYMBOL",
-                              "name": "typed_parameter"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "STRING",
-                          "value": ")"
-                        }
-                      ]
+                      "type": "SYMBOL",
+                      "name": "parenthesized_expression"
                     }
                   ]
                 },
@@ -3958,45 +3333,19 @@
                           },
                           {
                             "type": "SYMBOL",
-                            "name": "slurp_parameter"
+                            "name": "splat_expression"
                           },
                           {
                             "type": "SYMBOL",
-                            "name": "typed_parameter"
+                            "name": "typed_expression"
                           },
                           {
                             "type": "SYMBOL",
                             "name": "tuple_expression"
                           },
                           {
-                            "type": "SEQ",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": "("
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "identifier"
-                                  },
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "slurp_parameter"
-                                  },
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "typed_parameter"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": ")"
-                              }
-                            ]
+                            "type": "SYMBOL",
+                            "name": "parenthesized_expression"
                           }
                         ]
                       }
@@ -4020,34 +3369,16 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "interpolation_expression"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "identifier"
         },
         {
           "type": "STRING",
           "value": "="
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_expression"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "named_field"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_expression"
         }
       ]
     },
@@ -4066,11 +3397,35 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_number"
+                "name": "integer_literal"
               },
               {
                 "type": "SYMBOL",
-                "name": "_quotable"
+                "name": "float_literal"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "curly_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "parenthesized_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "tuple_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_array"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_string"
               }
             ]
           }
@@ -4092,7 +3447,11 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_number"
+                "name": "integer_literal"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "float_literal"
               },
               {
                 "type": "SYMBOL",
@@ -4370,23 +3729,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "ternary_expression"
-        },
-        {
-          "type": "SYMBOL",
           "name": "typed_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "function_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "juxtaposition_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "compound_assignment_expression"
+          "name": "unary_typed_expression"
         },
         {
           "type": "SYMBOL",
@@ -4503,7 +3850,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 16,
+          "value": 17,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4546,7 +3893,7 @@
         },
         {
           "type": "PREC_RIGHT",
-          "value": 17,
+          "value": 18,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4572,7 +3919,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 18,
+          "value": 19,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4598,7 +3945,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 19,
+          "value": 20,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4624,7 +3971,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 20,
+          "value": 21,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4659,7 +4006,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 21,
+          "value": 22,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4685,7 +4032,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 22,
+          "value": 23,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4711,7 +4058,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 23,
+          "value": 24,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4804,7 +4151,7 @@
     },
     "range_expression": {
       "type": "PREC_LEFT",
-      "value": 19,
+      "value": 20,
       "content": {
         "type": "SEQ",
         "members": [
@@ -4828,7 +4175,7 @@
     },
     "splat_expression": {
       "type": "PREC",
-      "value": 19,
+      "value": 20,
       "content": {
         "type": "SEQ",
         "members": [
@@ -4916,6 +4263,28 @@
         ]
       }
     },
+    "unary_typed_expression": {
+      "type": "PREC_RIGHT",
+      "value": 25,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "::"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_primary_expression"
+              }
+            ]
+          }
+        ]
+      }
+    },
     "function_expression": {
       "type": "PREC_RIGHT",
       "value": 10,
@@ -4931,16 +4300,11 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "parameter_list"
+                "name": "argument_list"
               },
               {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "typed_expression"
-                },
-                "named": true,
-                "value": "typed_parameter"
+                "type": "SYMBOL",
+                "name": "typed_expression"
               }
             ]
           },
@@ -5031,7 +4395,7 @@
     },
     "where_expression": {
       "type": "PREC_LEFT",
-      "value": 24,
+      "value": 16,
       "content": {
         "type": "SEQ",
         "members": [
@@ -5134,23 +4498,6 @@
     "identifier": {
       "type": "SYMBOL",
       "name": "_word_identifier"
-    },
-    "_number": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "boolean_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "integer_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "float_literal"
-        }
-      ]
     },
     "boolean_literal": {
       "type": "CHOICE",
@@ -8944,85 +8291,27 @@
   ],
   "conflicts": [
     [
-      "_function_signature",
-      "_quotable"
-    ],
-    [
-      "_function_signature",
+      "juxtaposition_expression",
       "_primary_expression"
     ],
     [
-      "_function_signature",
-      "parameter_list",
-      "_quotable"
-    ],
-    [
-      "_function_signature",
+      "juxtaposition_expression",
       "_expression"
-    ],
-    [
-      "_quotable",
-      "named_field",
-      "optional_parameter"
-    ],
-    [
-      "_quotable",
-      "named_field"
-    ],
-    [
-      "optional_parameter",
-      "named_field"
-    ],
-    [
-      "_quotable",
-      "typed_parameter"
-    ],
-    [
-      "_quotable",
-      "slurp_parameter"
-    ],
-    [
-      "_quotable",
-      "optional_parameter"
-    ],
-    [
-      "_quotable",
-      "keyword_parameters"
-    ],
-    [
-      "parameter_list",
-      "_quotable"
-    ],
-    [
-      "parameter_list",
-      "_primary_expression"
-    ],
-    [
-      "parameter_list",
-      "argument_list"
-    ],
-    [
-      "_primary_expression",
-      "typed_parameter"
-    ],
-    [
-      "_primary_expression",
-      "keyword_parameters"
-    ],
-    [
-      "_primary_expression",
-      "named_field"
     ],
     [
       "matrix_row",
       "comprehension_expression"
     ],
     [
-      "juxtaposition_expression",
-      "_number"
+      "argument_list",
+      "tuple_expression"
     ],
     [
-      "juxtaposition_expression",
+      "argument_list",
+      "parenthesized_expression"
+    ],
+    [
+      "named_field",
       "_primary_expression"
     ]
   ],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -174,6 +174,10 @@
         "named": true
       },
       {
+        "type": "unary_typed_expression",
+        "named": true
+      },
+      {
         "type": "vector_expression",
         "named": true
       },
@@ -293,6 +297,10 @@
       "types": [
         {
           "type": "adjoint_expression",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
           "named": true
         },
         {
@@ -422,26 +430,7 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "named_field",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "bare_tuple",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "_expression",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -481,6 +470,10 @@
         },
         {
           "type": "argument_list",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
           "named": true
         },
         {
@@ -584,6 +577,10 @@
         },
         {
           "type": "argument_list",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
           "named": true
         },
         {
@@ -694,11 +691,7 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -755,11 +748,7 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -803,14 +792,6 @@
         {
           "type": "assignment",
           "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "typed_expression",
-          "named": true
         }
       ]
     }
@@ -847,19 +828,15 @@
           "named": true
         },
         {
+          "type": "argument_list",
+          "named": true
+        },
+        {
           "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "parameter_list",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -882,11 +859,7 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -920,11 +893,7 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -967,6 +936,10 @@
         "types": [
           {
             "type": "adjoint_expression",
+            "named": true
+          },
+          {
+            "type": "boolean_literal",
             "named": true
           },
           {
@@ -1108,11 +1081,7 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -1133,10 +1102,6 @@
       "types": [
         {
           "type": "_expression",
-          "named": true
-        },
-        {
-          "type": "typed_parameter",
           "named": true
         }
       ]
@@ -1174,15 +1139,11 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
           "type": "for_binding",
           "named": true
         },
         {
-          "type": "short_function_definition",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -1191,145 +1152,10 @@
   {
     "type": "function_definition",
     "named": true,
-    "fields": {
-      "name": {
-        "multiple": true,
-        "required": false,
-        "types": [
-          {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
-            "type": "field_expression",
-            "named": true
-          },
-          {
-            "type": "function_object",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "interpolation_expression",
-            "named": true
-          },
-          {
-            "type": "operator",
-            "named": true
-          }
-        ]
-      },
-      "parameters": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "parameter_list",
-            "named": true
-          }
-        ]
-      },
-      "return_type": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "adjoint_expression",
-            "named": true
-          },
-          {
-            "type": "broadcast_call_expression",
-            "named": true
-          },
-          {
-            "type": "call_expression",
-            "named": true
-          },
-          {
-            "type": "character_literal",
-            "named": true
-          },
-          {
-            "type": "command_literal",
-            "named": true
-          },
-          {
-            "type": "comprehension_expression",
-            "named": true
-          },
-          {
-            "type": "curly_expression",
-            "named": true
-          },
-          {
-            "type": "field_expression",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "index_expression",
-            "named": true
-          },
-          {
-            "type": "interpolation_expression",
-            "named": true
-          },
-          {
-            "type": "macrocall_expression",
-            "named": true
-          },
-          {
-            "type": "matrix_expression",
-            "named": true
-          },
-          {
-            "type": "parametrized_type_expression",
-            "named": true
-          },
-          {
-            "type": "parenthesized_expression",
-            "named": true
-          },
-          {
-            "type": "prefixed_command_literal",
-            "named": true
-          },
-          {
-            "type": "prefixed_string_literal",
-            "named": true
-          },
-          {
-            "type": "quote_expression",
-            "named": true
-          },
-          {
-            "type": "string_literal",
-            "named": true
-          },
-          {
-            "type": "tuple_expression",
-            "named": true
-          },
-          {
-            "type": "vector_expression",
-            "named": true
-          }
-        ]
-      }
-    },
+    "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "_expression",
@@ -1340,19 +1166,11 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
+          "type": "open_tuple",
           "named": true
         },
         {
-          "type": "short_function_definition",
-          "named": true
-        },
-        {
-          "type": "type_parameter_list",
-          "named": true
-        },
-        {
-          "type": "where_clause",
+          "type": "signature",
           "named": true
         }
       ]
@@ -1371,139 +1189,11 @@
           "named": true
         },
         {
+          "type": "argument_list",
+          "named": true
+        },
+        {
           "type": "assignment",
-          "named": true
-        },
-        {
-          "type": "parameter_list",
-          "named": true
-        },
-        {
-          "type": "typed_parameter",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "function_object",
-    "named": true,
-    "fields": {
-      "parameter": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "interpolation_expression",
-            "named": true
-          },
-          {
-            "type": "tuple_expression",
-            "named": true
-          }
-        ]
-      },
-      "type": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "adjoint_expression",
-            "named": true
-          },
-          {
-            "type": "broadcast_call_expression",
-            "named": true
-          },
-          {
-            "type": "call_expression",
-            "named": true
-          },
-          {
-            "type": "character_literal",
-            "named": true
-          },
-          {
-            "type": "command_literal",
-            "named": true
-          },
-          {
-            "type": "comprehension_expression",
-            "named": true
-          },
-          {
-            "type": "curly_expression",
-            "named": true
-          },
-          {
-            "type": "field_expression",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "index_expression",
-            "named": true
-          },
-          {
-            "type": "interpolation_expression",
-            "named": true
-          },
-          {
-            "type": "macrocall_expression",
-            "named": true
-          },
-          {
-            "type": "matrix_expression",
-            "named": true
-          },
-          {
-            "type": "parametrized_type_expression",
-            "named": true
-          },
-          {
-            "type": "parenthesized_expression",
-            "named": true
-          },
-          {
-            "type": "prefixed_command_literal",
-            "named": true
-          },
-          {
-            "type": "prefixed_string_literal",
-            "named": true
-          },
-          {
-            "type": "quote_expression",
-            "named": true
-          },
-          {
-            "type": "string_literal",
-            "named": true
-          },
-          {
-            "type": "tuple_expression",
-            "named": true
-          },
-          {
-            "type": "vector_expression",
-            "named": true
-          }
-        ]
-      }
-    },
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "where_clause",
           "named": true
         }
       ]
@@ -1518,27 +1208,15 @@
       "required": true,
       "types": [
         {
+          "type": "_expression",
+          "named": true
+        },
+        {
           "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "function_definition",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
-          "named": true
-        },
-        {
-          "type": "typed_expression",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -1606,11 +1284,7 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -1629,6 +1303,10 @@
           "named": true
         },
         {
+          "type": "import_path",
+          "named": true
+        },
+        {
           "type": "interpolation_expression",
           "named": true
         },
@@ -1641,7 +1319,22 @@
           "named": true
         },
         {
-          "type": "relative_qualifier",
+          "type": "scoped_identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "import_path",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
           "named": true
         },
         {
@@ -1668,6 +1361,10 @@
           "named": true
         },
         {
+          "type": "import_path",
+          "named": true
+        },
+        {
           "type": "interpolation_expression",
           "named": true
         },
@@ -1677,10 +1374,6 @@
         },
         {
           "type": "operator",
-          "named": true
-        },
-        {
-          "type": "relative_qualifier",
           "named": true
         },
         {
@@ -1704,6 +1397,10 @@
       "types": [
         {
           "type": "adjoint_expression",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
           "named": true
         },
         {
@@ -1803,10 +1500,6 @@
       "required": true,
       "types": [
         {
-          "type": "boolean_literal",
-          "named": true
-        },
-        {
           "type": "character_literal",
           "named": true
         },
@@ -1875,6 +1568,10 @@
       "types": [
         {
           "type": "adjoint_expression",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
           "named": true
         },
         {
@@ -1969,41 +1666,6 @@
     }
   },
   {
-    "type": "keyword_parameters",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "interpolation_expression",
-          "named": true
-        },
-        {
-          "type": "macrocall_expression",
-          "named": true
-        },
-        {
-          "type": "optional_parameter",
-          "named": true
-        },
-        {
-          "type": "slurp_parameter",
-          "named": true
-        },
-        {
-          "type": "typed_parameter",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "let_binding",
     "named": true,
     "fields": {},
@@ -2016,7 +1678,7 @@
           "named": true
         },
         {
-          "type": "named_field",
+          "type": "assignment",
           "named": true
         }
       ]
@@ -2039,15 +1701,11 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
           "type": "let_binding",
           "named": true
         },
         {
-          "type": "short_function_definition",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -2062,27 +1720,15 @@
       "required": true,
       "types": [
         {
+          "type": "_expression",
+          "named": true
+        },
+        {
           "type": "assignment",
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "function_definition",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
-          "named": true
-        },
-        {
-          "type": "typed_expression",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -2105,11 +1751,7 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -2118,39 +1760,10 @@
   {
     "type": "macro_definition",
     "named": true,
-    "fields": {
-      "name": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "interpolation_expression",
-            "named": true
-          },
-          {
-            "type": "operator",
-            "named": true
-          }
-        ]
-      },
-      "parameters": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "parameter_list",
-            "named": true
-          }
-        ]
-      }
-    },
+    "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "_expression",
@@ -2161,11 +1774,11 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
+          "type": "open_tuple",
           "named": true
         },
         {
-          "type": "short_function_definition",
+          "type": "signature",
           "named": true
         }
       ]
@@ -2208,6 +1821,10 @@
         },
         {
           "type": "argument_list",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
           "named": true
         },
         {
@@ -2371,11 +1988,7 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -2394,7 +2007,7 @@
           "named": true
         },
         {
-          "type": "named_field",
+          "type": "assignment",
           "named": true
         }
       ]
@@ -2411,9 +2024,20 @@
         {
           "type": "_expression",
           "named": true
-        },
+        }
+      ]
+    }
+  },
+  {
+    "type": "open_tuple",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
         {
-          "type": "named_field",
+          "type": "_expression",
           "named": true
         }
       ]
@@ -2425,72 +2049,6 @@
     "fields": {}
   },
   {
-    "type": "optional_parameter",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "_expression",
-          "named": true
-        },
-        {
-          "type": "typed_parameter",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "parameter_list",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "call_expression",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "interpolation_expression",
-          "named": true
-        },
-        {
-          "type": "keyword_parameters",
-          "named": true
-        },
-        {
-          "type": "macrocall_expression",
-          "named": true
-        },
-        {
-          "type": "optional_parameter",
-          "named": true
-        },
-        {
-          "type": "slurp_parameter",
-          "named": true
-        },
-        {
-          "type": "tuple_expression",
-          "named": true
-        },
-        {
-          "type": "typed_parameter",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "parametrized_type_expression",
     "named": true,
     "fields": {},
@@ -2500,6 +2058,10 @@
       "types": [
         {
           "type": "adjoint_expression",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
           "named": true
         },
         {
@@ -2607,10 +2169,6 @@
         },
         {
           "type": "if_clause",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
           "named": true
         }
       ]
@@ -2735,10 +2293,6 @@
       "required": true,
       "types": [
         {
-          "type": "boolean_literal",
-          "named": true
-        },
-        {
           "type": "character_literal",
           "named": true
         },
@@ -2818,11 +2372,7 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -2838,25 +2388,6 @@
       "types": [
         {
           "type": "_expression",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "relative_qualifier",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "scoped_identifier",
           "named": true
         }
       ]
@@ -2879,7 +2410,7 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -2929,6 +2460,10 @@
           "named": true
         },
         {
+          "type": "import_path",
+          "named": true
+        },
+        {
           "type": "interpolation_expression",
           "named": true
         },
@@ -2941,10 +2476,6 @@
           "named": true
         },
         {
-          "type": "relative_qualifier",
-          "named": true
-        },
-        {
           "type": "scoped_identifier",
           "named": true
         }
@@ -2952,139 +2483,15 @@
     }
   },
   {
-    "type": "short_function_definition",
+    "type": "signature",
     "named": true,
     "fields": {
-      "name": {
-        "multiple": true,
-        "required": true,
-        "types": [
-          {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
-            "type": "field_expression",
-            "named": true
-          },
-          {
-            "type": "function_object",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "interpolation_expression",
-            "named": true
-          },
-          {
-            "type": "operator",
-            "named": true
-          }
-        ]
-      },
-      "parameters": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "parameter_list",
-            "named": true
-          }
-        ]
-      },
       "return_type": {
         "multiple": false,
         "required": false,
         "types": [
           {
-            "type": "adjoint_expression",
-            "named": true
-          },
-          {
-            "type": "broadcast_call_expression",
-            "named": true
-          },
-          {
-            "type": "call_expression",
-            "named": true
-          },
-          {
-            "type": "character_literal",
-            "named": true
-          },
-          {
-            "type": "command_literal",
-            "named": true
-          },
-          {
-            "type": "comprehension_expression",
-            "named": true
-          },
-          {
-            "type": "curly_expression",
-            "named": true
-          },
-          {
-            "type": "field_expression",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "index_expression",
-            "named": true
-          },
-          {
-            "type": "interpolation_expression",
-            "named": true
-          },
-          {
-            "type": "macrocall_expression",
-            "named": true
-          },
-          {
-            "type": "matrix_expression",
-            "named": true
-          },
-          {
-            "type": "parametrized_type_expression",
-            "named": true
-          },
-          {
-            "type": "parenthesized_expression",
-            "named": true
-          },
-          {
-            "type": "prefixed_command_literal",
-            "named": true
-          },
-          {
-            "type": "prefixed_string_literal",
-            "named": true
-          },
-          {
-            "type": "quote_expression",
-            "named": true
-          },
-          {
-            "type": "string_literal",
-            "named": true
-          },
-          {
-            "type": "tuple_expression",
-            "named": true
-          },
-          {
-            "type": "vector_expression",
+            "type": "unary_typed_expression",
             "named": true
           }
         ]
@@ -3095,42 +2502,19 @@
       "required": true,
       "types": [
         {
-          "type": "_expression",
+          "type": "argument_list",
           "named": true
         },
         {
-          "type": "assignment",
+          "type": "call_expression",
           "named": true
         },
-        {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "type_parameter_list",
-          "named": true
-        },
-        {
-          "type": "where_clause",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "slurp_parameter",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
         {
           "type": "identifier",
           "named": true
         },
         {
-          "type": "typed_parameter",
+          "type": "where_clause",
           "named": true
         }
       ]
@@ -3153,11 +2537,7 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -3248,11 +2628,7 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
+          "type": "open_tuple",
           "named": true
         },
         {
@@ -3302,10 +2678,6 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
           "type": "catch_clause",
           "named": true
         },
@@ -3318,7 +2690,7 @@
           "named": true
         },
         {
-          "type": "short_function_definition",
+          "type": "open_tuple",
           "named": true
         }
       ]
@@ -3361,6 +2733,10 @@
       "types": [
         {
           "type": "adjoint_expression",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
           "named": true
         },
         {
@@ -3485,134 +2861,6 @@
     }
   },
   {
-    "type": "typed_parameter",
-    "named": true,
-    "fields": {
-      "parameter": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "interpolation_expression",
-            "named": true
-          },
-          {
-            "type": "tuple_expression",
-            "named": true
-          }
-        ]
-      },
-      "type": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "adjoint_expression",
-            "named": true
-          },
-          {
-            "type": "broadcast_call_expression",
-            "named": true
-          },
-          {
-            "type": "call_expression",
-            "named": true
-          },
-          {
-            "type": "character_literal",
-            "named": true
-          },
-          {
-            "type": "command_literal",
-            "named": true
-          },
-          {
-            "type": "comprehension_expression",
-            "named": true
-          },
-          {
-            "type": "curly_expression",
-            "named": true
-          },
-          {
-            "type": "field_expression",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "index_expression",
-            "named": true
-          },
-          {
-            "type": "interpolation_expression",
-            "named": true
-          },
-          {
-            "type": "macrocall_expression",
-            "named": true
-          },
-          {
-            "type": "matrix_expression",
-            "named": true
-          },
-          {
-            "type": "parametrized_type_expression",
-            "named": true
-          },
-          {
-            "type": "parenthesized_expression",
-            "named": true
-          },
-          {
-            "type": "prefixed_command_literal",
-            "named": true
-          },
-          {
-            "type": "prefixed_string_literal",
-            "named": true
-          },
-          {
-            "type": "quote_expression",
-            "named": true
-          },
-          {
-            "type": "string_literal",
-            "named": true
-          },
-          {
-            "type": "tuple_expression",
-            "named": true
-          },
-          {
-            "type": "vector_expression",
-            "named": true
-          }
-        ]
-      }
-    },
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "_expression",
-          "named": true
-        },
-        {
-          "type": "where_clause",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "unary_expression",
     "named": true,
     "fields": {},
@@ -3622,6 +2870,105 @@
       "types": [
         {
           "type": "_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "unary_typed_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "adjoint_expression",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "broadcast_call_expression",
+          "named": true
+        },
+        {
+          "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "command_literal",
+          "named": true
+        },
+        {
+          "type": "comprehension_expression",
+          "named": true
+        },
+        {
+          "type": "curly_expression",
+          "named": true
+        },
+        {
+          "type": "field_expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "interpolation_expression",
+          "named": true
+        },
+        {
+          "type": "macrocall_expression",
+          "named": true
+        },
+        {
+          "type": "matrix_expression",
+          "named": true
+        },
+        {
+          "type": "parametrized_type_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "prefixed_command_literal",
+          "named": true
+        },
+        {
+          "type": "prefixed_string_literal",
+          "named": true
+        },
+        {
+          "type": "quote_expression",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "tuple_expression",
+          "named": true
+        },
+        {
+          "type": "vector_expression",
           "named": true
         }
       ]
@@ -3704,11 +3051,7 @@
           "named": true
         },
         {
-          "type": "bare_tuple",
-          "named": true
-        },
-        {
-          "type": "short_function_definition",
+          "type": "open_tuple",
           "named": true
         }
       ]

--- a/test/corpus/collections.txt
+++ b/test/corpus/collections.txt
@@ -37,7 +37,7 @@ named tuple collections
 
 (source_file
   (parenthesized_expression
-    (assignment (identifier) (operator) (integer_literal)))
+    (assignment (identifier) (integer_literal)))
   (line_comment)
   (tuple_expression
     (named_field (identifier) (integer_literal)))

--- a/test/corpus/collections.txt
+++ b/test/corpus/collections.txt
@@ -37,7 +37,7 @@ named tuple collections
 
 (source_file
   (parenthesized_expression
-    (assignment (identifier) (integer_literal)))
+    (assignment (identifier) (operator) (integer_literal)))
   (line_comment)
   (tuple_expression
     (named_field (identifier) (integer_literal)))

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -174,29 +174,29 @@ end
 
   (function_definition
     name: (identifier)
-    parameters: (parameter_list))
+    parameters: (argument_list))
 
   (function_definition
     name: (identifier)
-    parameters: (parameter_list (identifier))
+    parameters: (argument_list (identifier))
     (identifier))
 
   (function_definition
     name: (field_expression value: (identifier) (identifier))
-    parameters: (parameter_list
-                  (typed_parameter
-                    parameter: (identifier)
-                    type: (identifier)))
+    parameters: (argument_list
+                  (typed_expression
+                    (identifier)
+                    (identifier)))
     (return_statement (integer_literal)))
 
   (function_definition
     name: (identifier)
-    parameters: (parameter_list (identifier))
+    parameters: (argument_list (identifier))
     (call_expression (identifier) (argument_list (identifier))))
 
   (function_definition
     name: (operator)
-    parameters: (parameter_list (identifier) (identifier))
+    parameters: (argument_list (identifier) (identifier))
     (binary_expression
       (identifier)
       (operator)
@@ -205,10 +205,10 @@ end
   ;; Anonymous function
   (function_definition
     name: (identifier)
-    parameters: (parameter_list (identifier) (identifier))
+    parameters: (argument_list (identifier) (identifier))
     (return_statement
       (function_definition
-        parameters: (parameter_list (identifier))
+        parameters: (argument_list (identifier))
         (call_expression
           (identifier)
           (argument_list (identifier) (identifier))))))
@@ -216,9 +216,9 @@ end
   ;; Function Objects
   (function_definition
     name: (function_object
-            parameter: (identifier)
-            type: (identifier))
-    parameters: (parameter_list)))
+            (identifier)
+            (identifier))
+    parameters: (argument_list)))
 
 
 ==============================
@@ -314,56 +314,54 @@ end
   ;; Parameters
   (function_definition
     name: (identifier)
-    parameters: (parameter_list
+    parameters: (argument_list
                   (identifier)
-                  (typed_parameter
-                    parameter: (identifier)
-                    type: (identifier))
-                  (optional_parameter (identifier) (integer_literal))
-                  (slurp_parameter (identifier))))
+                  (typed_expression
+                    (identifier)
+                    (identifier))
+                  (named_argument (identifier) (integer_literal))
+                  (splat_expression (identifier))))
 
   ;; Typed parameters
   (function_definition
-    parameters: (parameter_list
-                  (typed_parameter
-                    type: (parametrized_type_expression (identifier)
-                                                        (curly_expression (identifier))))
-                  (optional_parameter
-                    (typed_parameter
-                      parameter: (identifier)
-                      type: (identifier))
+    parameters: (argument_list
+                  (unary_typed_expression
+                    (parametrized_type_expression (identifier)
+                      (curly_expression (identifier))))
+                  (named_argument
+                    (typed_expression
+                      (identifier)
+                      (identifier))
                     (integer_literal))
-                  (slurp_parameter
-                    (typed_parameter
-                      parameter: (identifier)
-                      type: (identifier)))))
+                  (splat_expression
+                    (typed_expression
+                      (identifier)
+                      (identifier)))))
 
   ;; Keyword parameters
   (function_definition
     name: (identifier)
-    parameters: (parameter_list
+    parameters: (argument_list
       (identifier)
-      (slurp_parameter (identifier))
-      (keyword_parameters
-        (slurp_parameter (identifier)))))
+      (splat_expression (identifier))
+      (splat_expression (identifier))))
 
   (function_definition
     name: (identifier)
-    parameters: (parameter_list
-                  (keyword_parameters
+    parameters: (argument_list
+                  (identifier)
+                  (typed_expression
                     (identifier)
-                    (typed_parameter
-                      parameter: (identifier)
-                      type: (identifier))
-                    (optional_parameter (identifier) (integer_literal))
-                    (slurp_parameter (identifier))))
+                    (identifier))
+                  (named_argument (identifier) (integer_literal))
+                  (splat_expression (identifier)))
       (identifier))
 
   ;; Return types
   (function_definition
     name: (identifier)
-    parameters: (parameter_list (identifier))
-    return_type: (identifier)
+    parameters: (argument_list (identifier))
+    return_type: (unary_typed_expression (identifier))
     (call_expression
       (identifier)
       (argument_list
@@ -372,12 +370,12 @@ end
   ;; Important: "scoped" return types are still parsed as field expressions.
   (function_definition
     name: (identifier)
-    parameters: (parameter_list
+    parameters: (argument_list
                   (identifier)
-                  (typed_parameter
-                    parameter: (identifier)
-                    type: (field_expression value: (identifier) (identifier))))
-    return_type: (field_expression value: (identifier) (identifier))
+                  (typed_expression
+                    (identifier)
+                    (field_expression value: (identifier) (identifier))))
+    return_type: (unary_typed_expression (field_expression value: (identifier) (identifier)))
     (call_expression
       (identifier)
       (argument_list
@@ -406,26 +404,26 @@ end
 (source_file
   (function_definition
     name: (identifier)
-    parameters: (parameter_list (tuple_expression (identifier) (identifier)))
+    parameters: (argument_list (tuple_expression (identifier) (identifier)))
     (tuple_expression (identifier) (identifier)))
 
 
   (function_definition
     name: (identifier)
-    parameters: (parameter_list
-                  (optional_parameter
+    parameters: (argument_list
+                  (named_argument
                     (tuple_expression (identifier) (identifier))
                     (tuple_expression (integer_literal) (integer_literal))))
     (tuple_expression (identifier) (identifier)))
 
   (function_definition
     name: (identifier)
-    parameters: (parameter_list
-                  (typed_parameter
-                    parameter: (tuple_expression (identifier) (identifier))
-                    type: (parametrized_type_expression
-                            (identifier)
-                            (curly_expression (identifier) (identifier)))))
+    parameters: (argument_list
+                  (typed_expression
+                    (tuple_expression (identifier) (identifier))
+                    (parametrized_type_expression
+                      (identifier)
+                      (curly_expression (identifier) (identifier)))))
     (where_clause (identifier))
     (identifier)))
 
@@ -457,19 +455,19 @@ Base.show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m,
   ;; `where` without brackets
   (function_definition
     name: (identifier)
-    parameters: (parameter_list
-                  (typed_parameter
-                    parameter: (identifier)
-                    type: (identifier)))
+    parameters: (argument_list
+                  (typed_expression
+                    (identifier)
+                    (identifier)))
     (where_clause (identifier)))
 
   ;; `where`
   (function_definition
     name: (identifier)
-    parameters: (parameter_list
-                  (typed_parameter
-                    parameter: (identifier)
-                    type: (identifier)))
+    parameters: (argument_list
+                  (typed_expression
+                    (identifier)
+                    (identifier)))
     (where_clause
       (curly_expression
         (binary_expression
@@ -486,9 +484,7 @@ Base.show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m,
           (identifier)
           (argument_list
             (typed_expression (identifier) (identifier))
-            (typed_parameter
-              parameter: (identifier)
-              type: (identifier))))
+            (typed_expression (identifier) (identifier))))
         (curly_expression
           (binary_expression
             (identifier)
@@ -521,17 +517,17 @@ Base.show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m,
   ;; `where` clauses in parameters
   (function_definition
     name: (identifier)
-    parameters: (parameter_list
-                  (typed_parameter
-                    parameter: (identifier)
-                    type: (parametrized_type_expression
-                            (identifier)
-                            (curly_expression (identifier)))
-                    (where_clause
-                      (binary_expression
+    parameters: (argument_list
+                  (where_expression
+                    (typed_expression
+                      (identifier)
+                      (parametrized_type_expression
                         (identifier)
-                        (operator)
-                        (identifier)))))
+                        (curly_expression (identifier))))
+                    (binary_expression
+                      (identifier)
+                      (operator)
+                      (identifier))))
     (call_expression (identifier) (argument_list (identifier))))
 
   ;; Almost everything at once
@@ -542,11 +538,9 @@ Base.show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m,
         (identifier))
       (argument_list
         (typed_expression (identifier) (identifier))
-        (typed_parameter
-          type: (prefixed_string_literal prefix: (identifier)))
-        (typed_parameter
-          parameter: (identifier)
-          type: (identifier))
+        (unary_typed_expression
+          (prefixed_string_literal prefix: (identifier)))
+        (typed_expression (identifier) (identifier))
         (splat_expression (identifier))))
       (operator)
       (call_expression
@@ -572,16 +566,16 @@ macro count(args...) length(args) end
 (source_file
     (macro_definition
       (identifier)
-      (parameter_list
-        (typed_parameter (identifier) (identifier)))
+      (argument_list
+        (typed_expression (identifier) (identifier)))
       (call_expression
         (identifier)
         (argument_list (identifier))))
 
     (macro_definition
       (identifier)
-      (parameter_list
-        (slurp_parameter (identifier)))
+      (argument_list
+        (splat_expression (identifier)))
       (call_expression
         (identifier)
         (argument_list (identifier)))))

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -238,39 +238,49 @@ Base.foo(x) = x
 ---
 
 (source_file
-  (short_function_definition
-    name: (identifier)
-    parameters: (parameter_list (identifier))
+  (assignment
+    (call_expression
+      (identifier)
+      (argument_list (identifier)))
+    (operator)
     (binary_expression
       (identifier)
       (operator)
       (integer_literal)))
 
-  (short_function_definition
-    name: (field_expression value: (identifier) (identifier))
-    parameters: (parameter_list (identifier))
+  (assignment
+    (call_expression
+      (field_expression value: (identifier) (identifier))
+      (argument_list (identifier)))
+    (operator)
     (identifier))
 
-  (short_function_definition
-    name: (identifier)
-    parameters: (parameter_list (identifier))
+  (assignment
+    (call_expression
+      (identifier)
+      (argument_list (identifier)))
+    (operator)
     (call_expression
       (identifier)
       (argument_list
         (integer_literal)
         (identifier))))
 
-  (short_function_definition
-    name: (operator)
-    parameters: (parameter_list (identifier) (identifier))
+  (assignment
+    (call_expression
+      (operator)
+      (argument_list (identifier) (identifier)))
+    (operator)
     (binary_expression
       (identifier)
       (operator)
       (identifier)))
 
-  (short_function_definition
-    name: (operator)
-    parameters: (parameter_list (identifier) (identifier))
+  (assignment
+    (call_expression
+      (parenthesized_expression (operator))
+      (argument_list (identifier) (identifier)))
+    (operator)
     (binary_expression
       (identifier)
       (operator)
@@ -469,42 +479,43 @@ Base.show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m,
     (identifier))
 
   ;; Short function `where`
-  (short_function_definition
-    name: (identifier)
-    parameters: (parameter_list
-                  (typed_parameter
-                    parameter: (identifier)
-                    type: (identifier))
-                  (typed_parameter
-                    parameter: (identifier)
-                    type: (identifier)))
-    (where_clause
+  (assignment
+    (where_expression
       (where_expression
+        (call_expression
+          (identifier)
+          (argument_list
+            (typed_expression (identifier) (identifier))
+            (typed_parameter
+              parameter: (identifier)
+              type: (identifier))))
         (curly_expression
           (binary_expression
             (identifier)
             (operator)
-            (identifier)))
-        (curly_expression
-          (binary_expression
-            (identifier)
-            (operator)
-            (identifier)))))
+            (identifier))))
+      (curly_expression
+        (binary_expression
+          (identifier)
+          (operator)
+          (identifier))))
+    (operator)
     (binary_expression
       (identifier)
       (operator)
       (identifier)))
 
   ;; Short function with type parameters
-  (short_function_definition
-    name: (identifier)
-    (type_parameter_list (identifier))
-    parameters: (parameter_list
-                  (typed_parameter
-                    parameter: (identifier)
-                    type: (identifier)))
-    (where_clause
+  (assignment
+    (where_expression
+      (call_expression
+        (parametrized_type_expression
+          (identifier)
+          (curly_expression (identifier)))
+        (argument_list
+          (typed_expression (identifier) (identifier))))
       (curly_expression (identifier)))
+    (operator)
     (identifier))
 
   ;; `where` clauses in parameters
@@ -524,21 +535,20 @@ Base.show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m,
     (call_expression (identifier) (argument_list (identifier))))
 
   ;; Almost everything at once
-  (short_function_definition
-    name: (field_expression
-      value: (identifier)
-      (identifier))
-    parameters: (parameter_list
-      (typed_parameter
-        parameter: (identifier)
-        type: (identifier))
-      (typed_parameter
-        type: (prefixed_string_literal prefix: (identifier)))
-      (typed_parameter
-        parameter: (identifier)
-        type: (identifier))
-      (keyword_parameters
-        (slurp_parameter (identifier))))
+  (assignment
+    (call_expression
+      (field_expression
+        value: (identifier)
+        (identifier))
+      (argument_list
+        (typed_expression (identifier) (identifier))
+        (typed_parameter
+          type: (prefixed_string_literal prefix: (identifier)))
+        (typed_parameter
+          parameter: (identifier)
+          type: (identifier))
+        (splat_expression (identifier))))
+      (operator)
       (call_expression
         (identifier)
         (argument_list

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -324,7 +324,7 @@ end
           (typed_expression
             (identifier)
             (identifier))
-          (named_argument (identifier) (integer_literal))
+          (named_argument (identifier) (operator) (integer_literal))
           (splat_expression (identifier))))))
 
   ;; Typed parameters
@@ -338,6 +338,7 @@ end
           (typed_expression
             (identifier)
             (identifier))
+          (operator)
           (integer_literal))
         (splat_expression
           (typed_expression
@@ -363,7 +364,7 @@ end
           (typed_expression
             (identifier)
             (identifier))
-          (named_argument (identifier) (integer_literal))
+          (named_argument (identifier) (operator) (integer_literal))
           (splat_expression (identifier)))))
       (identifier))
 
@@ -431,6 +432,7 @@ end
         (argument_list
           (named_argument
             (tuple_expression (identifier) (identifier))
+            (operator)
             (tuple_expression (integer_literal) (integer_literal))))))
     (tuple_expression (identifier) (identifier)))
 

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -170,33 +170,34 @@ end
 
 (source_file
   (function_definition
-    name: (identifier))
+    (signature
+      (identifier)))
 
   (function_definition
-    name: (identifier)
-    parameters: (argument_list))
+    (signature
+      (call_expression (identifier) (argument_list))))
 
   (function_definition
-    name: (identifier)
-    parameters: (argument_list (identifier))
+    (signature
+      (call_expression (identifier) (argument_list (identifier))))
     (identifier))
 
   (function_definition
-    name: (field_expression value: (identifier) (identifier))
-    parameters: (argument_list
-                  (typed_expression
-                    (identifier)
-                    (identifier)))
+    (signature
+      (call_expression
+        (field_expression value: (identifier) (identifier))
+        (argument_list
+          (typed_expression (identifier) (identifier)))))
     (return_statement (integer_literal)))
 
   (function_definition
-    name: (identifier)
-    parameters: (argument_list (identifier))
+    (signature
+      (call_expression (identifier) (argument_list (identifier))))
     (call_expression (identifier) (argument_list (identifier))))
 
   (function_definition
-    name: (operator)
-    parameters: (argument_list (identifier) (identifier))
+    (signature
+      (call_expression (operator) (argument_list (identifier) (identifier))))
     (binary_expression
       (identifier)
       (operator)
@@ -204,21 +205,23 @@ end
 
   ;; Anonymous function
   (function_definition
-    name: (identifier)
-    parameters: (argument_list (identifier) (identifier))
+    (signature
+      (call_expression (identifier) (argument_list (identifier) (identifier))))
     (return_statement
       (function_definition
-        parameters: (argument_list (identifier))
+        (signature
+          (argument_list (identifier)))
         (call_expression
           (identifier)
           (argument_list (identifier) (identifier))))))
 
   ;; Function Objects
   (function_definition
-    name: (function_object
-            (identifier)
-            (identifier))
-    parameters: (argument_list)))
+    (signature
+      (call_expression
+        (parenthesized_expression
+          (typed_expression (identifier) (identifier)))
+        (argument_list)))))
 
 
 ==============================
@@ -313,69 +316,80 @@ end
 (source_file
   ;; Parameters
   (function_definition
-    name: (identifier)
-    parameters: (argument_list
-                  (identifier)
-                  (typed_expression
-                    (identifier)
-                    (identifier))
-                  (named_argument (identifier) (integer_literal))
-                  (splat_expression (identifier))))
+    (signature
+      (call_expression
+        (identifier)
+        (argument_list
+          (identifier)
+          (typed_expression
+            (identifier)
+            (identifier))
+          (named_argument (identifier) (integer_literal))
+          (splat_expression (identifier))))))
 
   ;; Typed parameters
   (function_definition
-    parameters: (argument_list
-                  (unary_typed_expression
-                    (parametrized_type_expression (identifier)
-                      (curly_expression (identifier))))
-                  (named_argument
-                    (typed_expression
-                      (identifier)
-                      (identifier))
-                    (integer_literal))
-                  (splat_expression
-                    (typed_expression
-                      (identifier)
-                      (identifier)))))
+    (signature
+      (argument_list
+        (unary_typed_expression
+          (parametrized_type_expression (identifier)
+            (curly_expression (identifier))))
+        (named_argument
+          (typed_expression
+            (identifier)
+            (identifier))
+          (integer_literal))
+        (splat_expression
+          (typed_expression
+            (identifier)
+            (identifier))))))
 
   ;; Keyword parameters
   (function_definition
-    name: (identifier)
-    parameters: (argument_list
-      (identifier)
-      (splat_expression (identifier))
-      (splat_expression (identifier))))
+    (signature
+      (call_expression
+        (identifier)
+        (argument_list
+          (identifier)
+          (splat_expression (identifier))
+          (splat_expression (identifier))))))
 
   (function_definition
-    name: (identifier)
-    parameters: (argument_list
-                  (identifier)
-                  (typed_expression
-                    (identifier)
-                    (identifier))
-                  (named_argument (identifier) (integer_literal))
-                  (splat_expression (identifier)))
+    (signature
+      (call_expression
+        (identifier)
+        (argument_list
+          (identifier)
+          (typed_expression
+            (identifier)
+            (identifier))
+          (named_argument (identifier) (integer_literal))
+          (splat_expression (identifier)))))
       (identifier))
 
   ;; Return types
   (function_definition
-    name: (identifier)
-    parameters: (argument_list (identifier))
-    return_type: (unary_typed_expression (identifier))
-    (call_expression
-      (identifier)
-      (argument_list
-        (binary_expression (identifier) (operator) (integer_literal)))))
+    (signature
+      (call_expression
+        (identifier)
+        (argument_list (identifier)))
+      return_type: (unary_typed_expression (identifier)))
+      (call_expression
+        (identifier)
+        (argument_list
+          (binary_expression (identifier) (operator) (integer_literal)))))
 
   ;; Important: "scoped" return types are still parsed as field expressions.
   (function_definition
-    name: (identifier)
-    parameters: (argument_list
-                  (identifier)
-                  (typed_expression
-                    (identifier)
-                    (field_expression value: (identifier) (identifier))))
-    return_type: (unary_typed_expression (field_expression value: (identifier) (identifier)))
+    (signature
+      (call_expression
+        (identifier)
+        (argument_list
+          (identifier)
+          (typed_expression
+            (identifier)
+            (field_expression value: (identifier) (identifier)))))
+      return_type: (unary_typed_expression (field_expression value: (identifier) (identifier))))
     (call_expression
       (identifier)
       (argument_list
@@ -403,28 +417,34 @@ end
 ---
 (source_file
   (function_definition
-    name: (identifier)
-    parameters: (argument_list (tuple_expression (identifier) (identifier)))
+    (signature
+      (call_expression
+        (identifier)
+        (argument_list (tuple_expression (identifier) (identifier)))))
     (tuple_expression (identifier) (identifier)))
 
 
   (function_definition
-    name: (identifier)
-    parameters: (argument_list
-                  (named_argument
-                    (tuple_expression (identifier) (identifier))
-                    (tuple_expression (integer_literal) (integer_literal))))
+    (signature
+      (call_expression
+        (identifier)
+        (argument_list
+          (named_argument
+            (tuple_expression (identifier) (identifier))
+            (tuple_expression (integer_literal) (integer_literal))))))
     (tuple_expression (identifier) (identifier)))
 
   (function_definition
-    name: (identifier)
-    parameters: (argument_list
-                  (typed_expression
-                    (tuple_expression (identifier) (identifier))
-                    (parametrized_type_expression
-                      (identifier)
-                      (curly_expression (identifier) (identifier)))))
-    (where_clause (identifier))
+    (signature
+      (call_expression
+        (identifier)
+        (argument_list
+          (typed_expression
+            (tuple_expression (identifier) (identifier))
+            (parametrized_type_expression
+              (identifier)
+              (curly_expression (identifier) (identifier))))))
+      (where_clause (identifier)))
     (identifier)))
 
 
@@ -454,26 +474,30 @@ Base.show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m,
 (source_file
   ;; `where` without brackets
   (function_definition
-    name: (identifier)
-    parameters: (argument_list
-                  (typed_expression
-                    (identifier)
-                    (identifier)))
-    (where_clause (identifier)))
+    (signature
+      (call_expression
+        (identifier)
+        (argument_list
+          (typed_expression
+            (identifier)
+            (identifier))))
+      (where_clause (identifier))))
 
   ;; `where`
   (function_definition
-    name: (identifier)
-    parameters: (argument_list
-                  (typed_expression
-                    (identifier)
-                    (identifier)))
-    (where_clause
-      (curly_expression
-        (binary_expression
-          (identifier)
-          (operator)
-          (identifier))))
+    (signature
+      (call_expression
+        (identifier)
+        (argument_list
+          (typed_expression
+            (identifier)
+            (identifier))))
+      (where_clause
+        (curly_expression
+          (binary_expression
+            (identifier)
+            (operator)
+            (identifier)))))
     (identifier))
 
   ;; Short function `where`
@@ -516,18 +540,20 @@ Base.show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m,
 
   ;; `where` clauses in parameters
   (function_definition
-    name: (identifier)
-    parameters: (argument_list
-                  (where_expression
-                    (typed_expression
-                      (identifier)
-                      (parametrized_type_expression
-                        (identifier)
-                        (curly_expression (identifier))))
-                    (binary_expression
-                      (identifier)
-                      (operator)
-                      (identifier))))
+    (signature
+      (call_expression
+        (identifier)
+        (argument_list
+          (where_expression
+            (typed_expression
+              (identifier)
+              (parametrized_type_expression
+                (identifier)
+                (curly_expression (identifier))))
+            (binary_expression
+              (identifier)
+              (operator)
+              (identifier))))))
     (call_expression (identifier) (argument_list (identifier))))
 
   ;; Almost everything at once
@@ -565,17 +591,21 @@ macro count(args...) length(args) end
 
 (source_file
     (macro_definition
-      (identifier)
-      (argument_list
-        (typed_expression (identifier) (identifier)))
+      (signature
+        (call_expression
+          (identifier)
+          (argument_list
+            (typed_expression (identifier) (identifier)))))
       (call_expression
         (identifier)
         (argument_list (identifier))))
 
     (macro_definition
-      (identifier)
-      (argument_list
-        (splat_expression (identifier)))
+      (signature
+        (call_expression
+          (identifier)
+          (argument_list
+            (splat_expression (identifier)))))
       (call_expression
         (identifier)
         (argument_list (identifier)))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -285,12 +285,14 @@ f(@nospecialize(x)) = x
     (argument_list (identifier) (identifier) (identifier) (identifier)))
 
   ; Macros as parameters
-  (short_function_definition
-    (identifier)
-    (parameter_list
-      (macrocall_expression
-        (macro_identifier (identifier))
-        (argument_list (identifier))))
+  (assignment
+    (call_expression
+      (identifier)
+      (argument_list
+        (macrocall_expression
+          (macro_identifier (identifier))
+          (argument_list (identifier)))))
+    (operator)
     (identifier))
 
   ; Open vs closed macros

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -190,7 +190,7 @@ end
     (identifier)
     (argument_list (identifier))
     (do_clause
-      (parameter_list
+      (argument_list
         (identifier)
         (identifier))
       (call_expression
@@ -412,7 +412,7 @@ end
   (function_definition
     (interpolation_expression
       (parenthesized_expression (identifier)))
-    (parameter_list
+    (argument_list
       (interpolation_expression
         (parenthesized_expression (identifier))))
     (call_expression
@@ -520,7 +520,7 @@ x -> x^2
     (identifier)
     (binary_expression (identifier) (operator) (integer_literal)))
   (function_expression
-    (parameter_list (identifier) (identifier) (identifier))
+    (argument_list (identifier) (identifier) (identifier))
     (binary_expression
       (binary_expression
         (binary_expression (integer_literal) (operator) (identifier))
@@ -529,10 +529,10 @@ x -> x^2
       (operator)
       (identifier)))
   (function_expression
-    (parameter_list)
+    (argument_list)
     (integer_literal))
   (function_expression
-    (parameter_list)
+    (argument_list)
     (parenthesized_expression
       (call_expression (identifier) (argument_list (float_literal)))
       (compound_assignment_expression (identifier) (operator) (integer_literal))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -410,17 +410,19 @@ end
     (interpolation_expression
       (parenthesized_expression (splat_expression (identifier)))))
   (function_definition
-    (interpolation_expression
-      (parenthesized_expression (identifier)))
-    (argument_list
-      (interpolation_expression
-        (parenthesized_expression (identifier))))
-    (call_expression
-      (interpolation_expression
-        (parenthesized_expression (identifier)))
-      (argument_list
+    (signature
+      (call_expression
         (interpolation_expression
-          (parenthesized_expression (splat_expression (identifier))))))))
+          (parenthesized_expression (identifier)))
+        (argument_list
+          (interpolation_expression
+            (parenthesized_expression (identifier))))))
+      (call_expression
+        (interpolation_expression
+          (parenthesized_expression (identifier)))
+        (argument_list
+          (interpolation_expression
+            (parenthesized_expression (splat_expression (identifier))))))))
 
 
 ==============================

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -162,7 +162,7 @@ new{typeof(xs)}(xs)
     (identifier)
     (argument_list
       (identifier)
-      (named_argument (identifier) (identifier))))
+      (named_argument (identifier) (operator) (identifier))))
   (call_expression
     (identifier)
     (argument_list (identifier) (identifier)))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -260,7 +260,7 @@ Meta.@dump x = 1
   (macrocall_expression
     (macro_identifier (scoped_identifier (identifier) (identifier)))
     (macro_argument_list
-      (bare_tuple (integer_literal) (integer_literal))))
+      (open_tuple (integer_literal) (integer_literal))))
   (macrocall_expression
     (identifier)
     (macro_identifier (identifier))

--- a/test/corpus/operators.txt
+++ b/test/corpus/operators.txt
@@ -23,13 +23,13 @@ c &= d ÷= e
   (assignment
     (identifier)
     (operator)
-    (bare_tuple
+    (open_tuple
       (integer_literal)
       (integer_literal)
       (integer_literal)))
 
   (assignment
-    (bare_tuple
+    (open_tuple
       (identifier)
       (splat_expression (identifier)))
     (operator)

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -258,7 +258,7 @@ return a, b, c
   (return_statement)
   (return_statement (identifier))
   (return_statement (binary_expression (identifier) (operator) (identifier)))
-  (return_statement (bare_tuple (identifier) (identifier) (identifier))))
+  (return_statement (open_tuple (identifier) (identifier) (identifier))))
 
 
 ==============================
@@ -338,17 +338,17 @@ const y, z = 1, 2
     (assignment (identifier) (operator) (integer_literal)))
   (const_statement
     (assignment
-    (bare_tuple (identifier) (identifier))
+    (open_tuple (identifier) (identifier))
     (operator)
-    (bare_tuple (integer_literal) (integer_literal))))
+    (open_tuple (integer_literal) (integer_literal))))
   ; const statements inside tuples
   (tuple_expression
     (integer_literal)
     (const_statement
       (assignment
-        (bare_tuple (identifier) (identifier))
+        (open_tuple (identifier) (identifier))
         (operator)
-        (bare_tuple (integer_literal) (integer_literal))))))
+        (open_tuple (integer_literal) (integer_literal))))))
 
 
 ===============================
@@ -366,9 +366,9 @@ local function bar() 4 end
   (local_statement (identifier))
   (local_statement
     (assignment
-    (bare_tuple (identifier) (identifier))
+    (open_tuple (identifier) (identifier))
     (operator)
-    (bare_tuple (integer_literal) (integer_literal))))
+    (open_tuple (integer_literal) (integer_literal))))
   (local_statement
     (assignment
       (call_expression (identifier) (argument_list))
@@ -396,9 +396,9 @@ global function bar() 4 end
   (global_statement (identifier))
   (global_statement
     (assignment
-    (bare_tuple (identifier) (identifier))
+    (open_tuple (identifier) (identifier))
     (operator)
-    (bare_tuple (integer_literal) (integer_literal))))
+    (open_tuple (integer_literal) (integer_literal))))
   (global_statement
     (assignment
       (call_expression (identifier) (argument_list))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -376,7 +376,7 @@ local function bar() 4 end
       (integer_literal)))
   (local_statement
     (function_definition
-      (identifier) (parameter_list) (integer_literal))))
+      (identifier) (argument_list) (integer_literal))))
 
 
 ===============================
@@ -404,4 +404,4 @@ global function bar() 4 end
       (integer_literal)))
   (global_statement
     (function_definition
-      (identifier) (parameter_list) (integer_literal))))
+      (identifier) (argument_list) (integer_literal))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -303,8 +303,8 @@ import LinearAlgebra as la
 
   ;; Relative paths
   (import_statement
-    (relative_qualifier (identifier))
-    (relative_qualifier (identifier)))
+    (import_path (identifier))
+    (import_path (identifier)))
 
   ;; List import
   (import_statement (identifier) (identifier) (identifier))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -370,8 +370,10 @@ local function bar() 4 end
     (operator)
     (bare_tuple (integer_literal) (integer_literal))))
   (local_statement
-    (short_function_definition
-      (identifier) (parameter_list) (integer_literal)))
+    (assignment
+      (call_expression (identifier) (argument_list))
+      (operator)
+      (integer_literal)))
   (local_statement
     (function_definition
       (identifier) (parameter_list) (integer_literal))))
@@ -396,8 +398,10 @@ global function bar() 4 end
     (operator)
     (bare_tuple (integer_literal) (integer_literal))))
   (global_statement
-    (short_function_definition
-      (identifier) (parameter_list) (integer_literal)))
+    (assignment
+      (call_expression (identifier) (argument_list))
+      (operator)
+      (integer_literal)))
   (global_statement
     (function_definition
       (identifier) (parameter_list) (integer_literal))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -59,9 +59,9 @@ end
 (source_file
   (let_statement)
   (let_statement
-    (let_binding (identifier) (identifier))
+    (let_binding (identifier) (operator) (identifier))
     (identifier)
-    (let_binding (identifier) (identifier))
+    (let_binding (identifier) (operator) (identifier))
     (identifier)))
 
 

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -376,7 +376,9 @@ local function bar() 4 end
       (integer_literal)))
   (local_statement
     (function_definition
-      (identifier) (argument_list) (integer_literal))))
+      (signature
+        (call_expression (identifier) (argument_list)))
+        (integer_literal))))
 
 
 ===============================
@@ -404,4 +406,6 @@ global function bar() 4 end
       (integer_literal)))
   (global_statement
     (function_definition
-      (identifier) (argument_list) (integer_literal))))
+      (signature
+        (call_expression (identifier) (argument_list)))
+        (integer_literal))))


### PR DESCRIPTION
The main goal of this PR is to reduce duplication and remove unnecessary conflicts in the grammar. In particular, removing parameter and function signatures rules, since Julia doesn't have distinct syntactic constructs for these (they're parsed as expressions).


Breaking changes:

- Remove `short_function_definition`
  - short functions are now parsed as `(= (call …) …)` (like JuliaSyntax)
- Add visible `signature` rule in `function_definition` and `macro_definition`
  - This acts as a wrapper around a call or an argument list (if the function is anonymous).
- Add `unary_typed_expression`
  - Like `typed_expression`, this is a separate rule to make it easier to highlight the RHS as a type, tho it could probably be improved further.
- Add `_closed_assignment` to handle assignments inside brackets, where they cannot contain open tuples.
- Rename `bare_tuple` to `open_tuple` (to contrast with `_closed_macrocall` and `_closed_assignment`).
- Rename `relative_qualifier` to `import_path` (like JuliaSyntax).

Internal changes:
- Remove `_quotable`
- Remove `_number`
- Refactor `_operation`

Closes #88
Closes #98
Closes #113
Closes #119
Closes #129
Closes #125 