### PR TITLE
Add nodes that mark the content of string literals

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1041,20 +1041,22 @@ module.exports = grammar({
 
     string_literal: $ => seq(
       $._string_start,
-      repeat(choice($._string_content, $.string_interpolation, $.escape_sequence)),
+      optional($.string_content),
       $._string_end,
     ),
 
     command_literal: $ => seq(
       $._command_start,
-      repeat(choice($._string_content, $.string_interpolation, $.escape_sequence)),
+      optional($.string_content),
       $._command_end,
     ),
+
+    string_content: $ => repeat1(choice($._string_content, $.string_interpolation, $.escape_sequence)),
 
     prefixed_string_literal: $ => prec.left(seq(
       field('prefix', $.identifier),
       $._immediate_string_start,
-      repeat(choice($._string_content_no_interp, $.escape_sequence)),
+      optional($.raw_string_content),
       $._string_end,
       optional(field('suffix', $.identifier)),
     )),
@@ -1062,10 +1064,12 @@ module.exports = grammar({
     prefixed_command_literal: $ => prec.left(seq(
       field('prefix', $.identifier),
       $._immediate_command_start,
-      repeat(choice($._string_content_no_interp, $.escape_sequence)),
+      optional($.raw_string_content),
       $._command_end,
       optional(field('suffix', $.identifier)),
     )),
+
+    raw_string_content: $ => repeat1(choice($._string_content_no_interp, $.escape_sequence)),
 
     string_interpolation: $ => seq(
       '$',

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -567,7 +567,7 @@ Base.show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m,
       (argument_list
         (typed_expression (identifier) (identifier))
         (unary_typed_expression
-          (prefixed_string_literal prefix: (identifier)))
+          (prefixed_string_literal prefix: (identifier) (raw_string_content)))
         (typed_expression (identifier) (identifier))
         (splat_expression (identifier))))
       (operator)

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -77,8 +77,7 @@ df."a"
 
   (field_expression
     (identifier)
-    (string_literal)))
-
+    (string_literal (string_content))))
 
 ==============================
 index expressions
@@ -102,7 +101,7 @@ a[1, :]
       (integer_literal)
       (operator)))
   (index_expression
-    (string_literal)
+    (string_literal (string_content))
     (vector_expression (integer_literal))))
 
 
@@ -155,7 +154,7 @@ new{typeof(xs)}(xs)
 
 (source_file
   (call_expression (identifier) (argument_list))
-  (call_expression (identifier) (argument_list (string_literal) (integer_literal)))
+  (call_expression (identifier) (argument_list (string_literal (string_content)) (integer_literal)))
   (call_expression (identifier) (argument_list (splat_expression (identifier))))
 
   (call_expression
@@ -224,12 +223,12 @@ Meta.@dump x = 1
     (macro_identifier (identifier))
     (macro_argument_list
       (binary_expression (identifier) (operator) (identifier))
-      (string_literal)))
+      (string_literal (string_content))))
 
   (macrocall_expression
     (macro_identifier (identifier))
     (macro_argument_list
-      (string_literal)
+      (string_literal (string_content))
       (compound_statement (assignment (identifier) (operator) (identifier)))))
 
   (macrocall_expression
@@ -245,7 +244,7 @@ Meta.@dump x = 1
     (identifier)
     (argument_list
       (macrocall_expression (macro_identifier (identifier)))
-      (string_literal)))
+      (string_literal (string_content))))
 
   ; Nested macros
   (macrocall_expression
@@ -397,7 +396,7 @@ end
     (vector_expression
       (integer_literal)
       (integer_literal)))
-  (interpolation_expression (string_literal))
+  (interpolation_expression (string_literal (string_content)))
   (import_statement
     (selected_import
       (interpolation_expression (identifier))
@@ -481,7 +480,9 @@ x'x
     (field_expression (identifier) (identifier)))
   (juxtaposition_expression
     (integer_literal)
-    (prefixed_string_literal (identifier)))
+    (prefixed_string_literal
+      (identifier)
+      (raw_string_content)))
   (juxtaposition_expression
     (adjoint_expression (identifier))
     (identifier))

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -109,24 +109,40 @@ band = "Interpol"
 
 (source_file
   (string_literal)
-  (string_literal (escape_sequence))
-  (string_literal)
-  (string_literal (escape_sequence) (escape_sequence))
-  (string_literal)
+  (string_literal
+    (string_content
+      (escape_sequence)))
+  (string_literal
+    (string_content))
+  (string_literal
+    (string_content
+      (escape_sequence)
+      (escape_sequence)))
+  (string_literal
+    (string_content))
   (assignment
     (identifier)
     (operator)
-    (string_literal))
+    (string_literal
+      (string_content)))
   (string_literal
-    (string_interpolation (identifier)))
+    (string_content
+      (string_interpolation
+        (identifier))))
   (string_literal
-    (string_interpolation (juxtaposition_expression (integer_literal) (identifier))))
+    (string_content
+      (string_interpolation
+        (juxtaposition_expression
+          (integer_literal)
+          (identifier)))))
   (string_literal
-    (string_interpolation
-      (string_literal
-        (string_interpolation
-          (string_literal))))))
-
+    (string_content
+      (string_interpolation
+        (string_literal
+          (string_content
+            (string_interpolation
+              (string_literal
+                (string_content)))))))))
 
 ==============================
 command string literals
@@ -143,15 +159,23 @@ echo "\033[31mred\033[m"
 ---
 
 (source_file
-  (command_literal)
-  (prefixed_command_literal
-    prefix: (identifier))
-  (command_literal (string_interpolation (identifier)))
-  (command_literal (escape_sequence) (escape_sequence))
   (command_literal
-   (escape_sequence)
-   (escape_sequence)))
-
+    (string_content))
+  (prefixed_command_literal
+    prefix: (identifier)
+    (raw_string_content))
+  (command_literal
+    (string_content
+      (string_interpolation
+        (identifier))))
+  (command_literal
+    (string_content
+      (escape_sequence)
+      (escape_sequence)))
+  (command_literal
+    (string_content
+      (escape_sequence)
+      (escape_sequence))))
 
 ==============================
 non-standard string literals
@@ -168,17 +192,19 @@ K"\\"
     (identifier)
     (operator)
     (prefixed_string_literal
-        prefix: (identifier)
-        (escape_sequence)))
+      prefix: (identifier)
+      (raw_string_content
+        (escape_sequence))))
   (assignment
     (identifier)
     (operator)
     (prefixed_string_literal
-        prefix: (identifier)))
+      prefix: (identifier)
+      (raw_string_content)))
   (prefixed_string_literal
     prefix: (identifier)
-    (escape_sequence)))
-
+    (raw_string_content
+      (escape_sequence))))
 
 ==============================
 comments


### PR DESCRIPTION
This adds additional nodes within string literals and command literals that marks the actual contents of the string itself. This is useful for writing queries that need to do something just with the contents, rather than the entire literal including the quotes, e.g. language injections in Neovim.

Previously you would have to do some `#offset!` calls within the queries that perform the language injections. Now you can just match against the `string_content` and `raw_string_content` nodes directly and avoid having to compute offsets manually.

---

Some TODOs:

 - naming, I've gone with what seemed reasonable: `string_content` and `raw_string_content`. I couldn't come up with a nice way to unify the node types. Open to suggestions there.
 - must I commit a `tree-sitter generate` to this PR, or is that done separately before a tag is done?
 - even though this has touched a bunch of test files I'll still be adding some additional ones for some more edge cases if the general approach taken in the implementation is suitable.