### PR TITLE
fix: expose semicolons, remove generation warnings

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1155,7 +1155,7 @@ module.exports = grammar({
     _syntactic_operator: _ => choice('$', '.', '...', '->', '?'),
 
 
-    _terminator: _ => choice(/\r?\n/, /;+/),
+    _terminator: _ => choice(/\r?\n/, seq(';', repeat(token.immediate(';')))),
 
     block_comment: $ => seq(/#=/, $._block_comment_rest),
 
@@ -1188,7 +1188,7 @@ function sep1(separator, rule) {
  */
 function addDot(operatorString) {
   const operators = operatorString.trim().split(/\s+/);
-  return token(seq(optional('.'), choice(...operators)));
+  return token(seq(optional('.'), operators.length > 1 ? choice(...operators) : operators[0]));
 }
 
 /**

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5151,13 +5151,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "=>"
-              }
-            ]
+            "type": "STRING",
+            "value": "=>"
           }
         ]
       }
@@ -5809,13 +5804,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "||"
-              }
-            ]
+            "type": "STRING",
+            "value": "||"
           }
         ]
       }
@@ -5838,13 +5828,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "&&"
-              }
-            ]
+            "type": "STRING",
+            "value": "&&"
           }
         ]
       }
@@ -7028,13 +7013,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "|>"
-              }
-            ]
+            "type": "STRING",
+            "value": "|>"
           }
         ]
       }
@@ -7057,13 +7037,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "<|"
-              }
-            ]
+            "type": "STRING",
+            "value": "<|"
           }
         ]
       }
@@ -7741,13 +7716,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "//"
-              }
-            ]
+            "type": "STRING",
+            "value": "//"
           }
         ]
       }
@@ -7956,13 +7926,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "~"
-              }
-            ]
+            "type": "STRING",
+            "value": "~"
           }
         ]
       }
@@ -8119,8 +8084,23 @@
           "value": "\\r?\\n"
         },
         {
-          "type": "PATTERN",
-          "value": ";+"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": ";"
+                }
+              }
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
This commit exposes semicolon terminators as anonymous nodes that can be queried, and removes the following warnings upon generating the parser:

Warning: rule _pair_operator is just a `seq` or `choice` rule with a single element. This is unnecessary.
Warning: rule _lazy_or_operator is just a `seq` or `choice` rule with a single element. This is unnecessary.
Warning: rule _lazy_and_operator is just a `seq` or `choice` rule with a single element. This is unnecessary.
Warning: rule _pipe_right_operator is just a `seq` or `choice` rule with a single element. This is unnecessary.
Warning: rule _pipe_left_operator is just a `seq` or `choice` rule with a single element. This is unnecessary.
Warning: rule _rational_operator is just a `seq` or `choice` rule with a single element. This is unnecessary.
Warning: rule _tilde_operator is just a `seq` or `choice` rule with a single element. This is unnecessary.